### PR TITLE
fix: security hardening - safe-mode, shell injection, API auth, CORS

### DIFF
--- a/cli/scan.go
+++ b/cli/scan.go
@@ -75,10 +75,6 @@ func runScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	// --safe-mode is advisory for now: the engine will consume this flag
-	// in a follow-up commit to cap RPS + block destructive techniques.
-	_ = safeMode
-
 	// Resolve the API key: env first (CI-friendly), then OS keychain
 	// (the path 'pentestswarm init' writes to), with config.yaml as the
 	// last-resort fallback so old setups keep working.
@@ -153,11 +149,12 @@ func runScan(cmd *cobra.Command, args []string) error {
 		Objective:        objective,
 		Mode:             mode,
 		DryRun:           dryRun,
+		SafeMode:         safeMode,
 		OutputDir:        output,
 		Format:           format,
 		Provider:         providerOverride,
 		PublishThreshold: publishThreshold,
-		ExplorationBias: explorationBias,
+		ExplorationBias:  explorationBias,
 	}
 
 	// Event handler for live output
@@ -301,7 +298,6 @@ func init() {
 	scanCmd.Flags().Bool("estimate", false, "print expected LLM spend in USD and exit without scanning")
 	scanCmd.Flags().String("target-class", "medium", "estimate sizing: small | medium | large")
 	scanCmd.Flags().Bool("safe-mode", false, "cap RPS + forbid destructive techniques (for programs that disallow automated scanning)")
-	scanCmd.Flags().String("auth-token", "", "authorization token")
 
 	_ = scanCmd.MarkFlagRequired("scope")
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,6 +7,9 @@
 server:
   host: "0.0.0.0"          # API server bind address
   port: 8080               # API server port
+  api_key: ""              # Set to a strong random string to require X-API-Key on all API routes.
+                           # Leave empty only for local development. Env: PENTESTSWARM_SERVER_API_KEY
+  cors_origins: "http://localhost:3000"  # Comma-separated allowed CORS origins. Avoid "*" in production.
 
 # --- Database ---
 database:

--- a/internal/agent/exploit/executor.go
+++ b/internal/agent/exploit/executor.go
@@ -127,17 +127,19 @@ func (e *Executor) Execute(ctx context.Context, step pipeline.AttackStep, campai
 		}, fmt.Errorf("unsafe command: %w", err)
 	}
 
-	// Safe-mode: reject destructive tokens before execution. This is
-	// a belt-and-braces check — programs that disallow automated
-	// scanning would NEVER want rm / DROP / etc. to fire accidentally.
+	// Safe-mode: reject destructive tokens before execution. Scan every
+	// word within each argument so that tokens embedded in quoted payloads
+	// (e.g. -d 'drop table users') are caught, not just top-level argv words.
 	if e.safeMode {
 		for _, part := range parts {
-			if _, bad := destructiveTokens[strings.ToLower(part)]; bad {
-				msg := fmt.Sprintf("safe-mode blocked destructive token %q (drop --safe-mode to override)", part)
-				return &pipeline.ExecutionResult{
-					StepID: step.ID, CampaignID: campaignID, CommandExecuted: step.Command,
-					Output: "BLOCKED: " + msg, Success: false, ExecutedAt: start,
-				}, fmt.Errorf("%s", msg)
+			for _, word := range strings.Fields(part) {
+				if _, bad := destructiveTokens[strings.ToLower(word)]; bad {
+					msg := fmt.Sprintf("safe-mode blocked destructive token %q (drop --safe-mode to override)", word)
+					return &pipeline.ExecutionResult{
+						StepID: step.ID, CampaignID: campaignID, CommandExecuted: step.Command,
+						Output: "BLOCKED: " + msg, Success: false, ExecutedAt: start,
+					}, fmt.Errorf("%s", msg)
+				}
 			}
 		}
 	}

--- a/internal/agent/exploit/shellparse.go
+++ b/internal/agent/exploit/shellparse.go
@@ -1,107 +1,14 @@
 package exploit
 
-import (
-	"fmt"
-	"strings"
-	"unicode"
-)
+import "github.com/Armur-Ai/Pentest-Swarm-AI/internal/shellsafe"
 
-// parseCommand splits a command string into argv while respecting single
-// and double quotes. It refuses any command containing shell metacharacters
-// (|, >, <, &, ;, backtick, $(, newline) — callers that need a shell must
-// explicitly wrap their command in `sh -c "..."` as a single quoted arg.
+// ParseCommand splits a command string into argv while respecting single and
+// double quotes. It refuses any command containing shell metacharacters (|, >,
+// <, &, ;, backtick, $(, newlines) unless they appear inside quotes — callers
+// that need a real shell must wrap their command in sh -c "..." explicitly.
 //
-// This is a defence-in-depth layer. Scope validation still runs first.
-// ParseCommand is the exported entry point for callers outside this
-// package (e.g. the ConfirmationAgent re-runs reproduction commands
-// and wants the same safety posture).
+// This is a defence-in-depth layer; scope validation still runs first.
+// ParseCommand is exported so the ConfirmationAgent can use the same policy.
 func ParseCommand(cmd string) ([]string, error) { return parseCommand(cmd) }
 
-func parseCommand(cmd string) ([]string, error) {
-	// Reject obvious shell metacharacters unless they're inside quotes.
-	if err := rejectUnsafe(cmd); err != nil {
-		return nil, err
-	}
-
-	var (
-		args []string
-		cur  strings.Builder
-		in   rune // 0, '\'', or '"'
-		esc  bool // previous char was backslash (inside double quotes only)
-	)
-	flush := func() {
-		if cur.Len() > 0 {
-			args = append(args, cur.String())
-			cur.Reset()
-		}
-	}
-
-	for _, r := range cmd {
-		switch {
-		case esc:
-			cur.WriteRune(r)
-			esc = false
-		case in == '"' && r == '\\':
-			esc = true
-		case in == 0 && (r == '\'' || r == '"'):
-			in = r
-		case in != 0 && r == in:
-			in = 0
-		case in == 0 && unicode.IsSpace(r):
-			flush()
-		default:
-			cur.WriteRune(r)
-		}
-	}
-	if in != 0 {
-		return nil, fmt.Errorf("unterminated %c quote", in)
-	}
-	flush()
-	if len(args) == 0 {
-		return nil, fmt.Errorf("empty command")
-	}
-	return args, nil
-}
-
-// rejectUnsafe scans for shell metacharacters outside of quoted regions.
-// It's intentionally strict — false positives are a feature, not a bug,
-// since any user who needs those characters should wrap in sh -c explicitly.
-func rejectUnsafe(cmd string) error {
-	var (
-		in  rune
-		esc bool
-	)
-	for i, r := range cmd {
-		switch {
-		case esc:
-			esc = false
-			continue
-		case in == '"' && r == '\\':
-			esc = true
-			continue
-		case in == 0 && (r == '\'' || r == '"'):
-			in = r
-			continue
-		case in != 0 && r == in:
-			in = 0
-			continue
-		}
-		if in != 0 {
-			continue
-		}
-		switch r {
-		case '|', '>', '<', '&', ';', '`':
-			return fmt.Errorf("disallowed shell metachar %q at position %d", r, i)
-		case '\n', '\r':
-			return fmt.Errorf("newline in command at position %d", i)
-		case '$':
-			// Reject `$(...)` command substitution. A literal $ followed by
-			// a letter or { is allowed (env-var expansion happens inside exec.Cmd,
-			// not via the shell, so it's inert anyway).
-			if i+1 < len(cmd) && cmd[i+1] == '(' {
-				return fmt.Errorf("command substitution $( at position %d", i)
-			}
-		}
-	}
-	return nil
-}
+func parseCommand(cmd string) ([]string, error) { return shellsafe.Parse(cmd) }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -59,10 +59,19 @@ func NewServer(port int, cfg *config.Config) *Server {
 	app.Use(logger.New(logger.Config{
 		Format: "${time} ${status} ${method} ${path} ${latency}\n",
 	}))
+
+	corsOrigins := cfg.Server.CORSOrigins
+	if corsOrigins == "" {
+		corsOrigins = "http://localhost:3000"
+	}
 	app.Use(cors.New(cors.Config{
-		AllowOrigins: "*",
+		AllowOrigins: corsOrigins,
 		AllowHeaders: "Origin, Content-Type, Accept, X-API-Key",
 	}))
+
+	if cfg.Server.APIKey != "" {
+		app.Use(apiKeyMiddleware(cfg.Server.APIKey))
+	}
 
 	s := &Server{
 		app:    app,
@@ -403,4 +412,20 @@ func errorHandler(c *fiber.Ctx, err error) error {
 			Message: err.Error(),
 		},
 	})
+}
+
+// apiKeyMiddleware rejects requests that don't carry the correct X-API-Key
+// header. The health endpoint is excluded so load-balancer probes still work.
+func apiKeyMiddleware(want string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if c.Path() == "/api/v1/health" {
+			return c.Next()
+		}
+		if c.Get("X-API-Key") != want {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": apiError{Code: "UNAUTHORIZED", Message: "missing or invalid X-API-Key"},
+			})
+		}
+		return c.Next()
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,8 +25,10 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	Host string `mapstructure:"host"`
-	Port int    `mapstructure:"port"`
+	Host        string `mapstructure:"host"`
+	Port        int    `mapstructure:"port"`
+	APIKey      string `mapstructure:"api_key"`      // required when serve is exposed; empty = no auth (dev only)
+	CORSOrigins string `mapstructure:"cors_origins"` // comma-separated; "*" only for local dev
 }
 
 type DatabaseConfig struct {
@@ -173,6 +175,8 @@ func Load(path string) (*Config, error) {
 	// Defaults
 	v.SetDefault("server.host", "0.0.0.0")
 	v.SetDefault("server.port", 8080)
+	v.SetDefault("server.api_key", "")
+	v.SetDefault("server.cors_origins", "http://localhost:3000")
 	v.SetDefault("database.host", "localhost")
 	v.SetDefault("database.port", 5432)
 	v.SetDefault("database.user", "pentestswarm")

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -43,6 +43,10 @@ type CampaignConfig struct {
 	// only verified / not-superseded findings ship. 0.1 is "aggressive
 	// mode" which includes suspected-but-unverified findings.
 	PublishThreshold float64
+
+	// SafeMode forwards the --safe-mode flag to the exploit executor, which
+	// rejects destructive tokens (rm, DROP, kill, chmod …) before they run.
+	SafeMode bool
 }
 
 // EventCallback is called for every campaign event (for TUI/streaming).
@@ -288,7 +292,7 @@ func (r *Runner) Run(ctx context.Context, cc CampaignConfig, onEvent EventCallba
 			&scope.ScopeDefinition{AllowedDomains: scopeDef.AllowedDomains, AllowedCIDRs: scopeDef.AllowedCIDRs},
 			r.cleanup,
 			cc.DryRun,
-		)
+		).WithSafeMode(cc.SafeMode)
 
 		for _, path := range attackPlan.Paths[:min(3, len(attackPlan.Paths))] {
 			for _, step := range path.Steps {

--- a/internal/engine/swarm_runner.go
+++ b/internal/engine/swarm_runner.go
@@ -146,7 +146,7 @@ func (r *Runner) RunSwarm(ctx context.Context, cc CampaignConfig, onEvent EventC
 		&scope.ScopeDefinition{AllowedDomains: scopeDef.AllowedDomains, AllowedCIDRs: scopeDef.AllowedCIDRs},
 		r.cleanup,
 		cc.DryRun,
-	)
+	).WithSafeMode(cc.SafeMode)
 
 	// Pheromone tuning: config file if present, else embedded defaults.
 	// --exploration-bias on the CLI applies a multiplier at lookup time.

--- a/internal/pipeline/cleanup_memory.go
+++ b/internal/pipeline/cleanup_memory.go
@@ -2,10 +2,12 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"sync"
 	"time"
 
+	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/shellsafe"
 	"github.com/google/uuid"
 )
 
@@ -85,13 +87,17 @@ func (m *MemoryCleanupRegistry) PendingCleanup(ctx context.Context, campaignID u
 	return out, nil
 }
 
-// DefaultCleanupExec runs a cleanup command string via /bin/sh -c.
-// Cleanup commands are authored by our own agents, not users, so shell
-// expansion here is acceptable — but callers that want stricter semantics
-// can pass a custom exec to NewMemoryCleanupRegistry.
+// DefaultCleanupExec runs a cleanup command without a shell. The command is
+// parsed with the same quote-aware, metachar-rejecting parser the exploit
+// executor uses, so prompt-injected cleanup commands cannot abuse shell
+// features even when the LLM outputs a crafted string.
 func DefaultCleanupExec(ctx context.Context, cmdStr string) error {
+	parts, err := shellsafe.Parse(cmdStr)
+	if err != nil {
+		return fmt.Errorf("unsafe cleanup command: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
 	return cmd.Run()
 }

--- a/internal/shellsafe/shellsafe.go
+++ b/internal/shellsafe/shellsafe.go
@@ -1,0 +1,97 @@
+// Package shellsafe provides a quote-aware command parser that rejects shell
+// metacharacters outside of quoted regions. Both the exploit executor and the
+// cleanup executor use this so the same safety policy applies to every command
+// the tool fires — LLM-generated or user-authored.
+package shellsafe
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// Parse splits a command string into argv, respecting single and double quotes.
+// It rejects any unquoted shell metacharacters (|, >, <, &, ;, backtick, $(),
+// newlines). Callers that genuinely need a shell must wrap their command in
+// sh -c "..." as a single quoted argument — that makes the intent explicit.
+func Parse(cmd string) ([]string, error) {
+	if err := rejectUnsafe(cmd); err != nil {
+		return nil, err
+	}
+
+	var (
+		args []string
+		cur  strings.Builder
+		in   rune
+		esc  bool
+	)
+	flush := func() {
+		if cur.Len() > 0 {
+			args = append(args, cur.String())
+			cur.Reset()
+		}
+	}
+
+	for _, r := range cmd {
+		switch {
+		case esc:
+			cur.WriteRune(r)
+			esc = false
+		case in == '"' && r == '\\':
+			esc = true
+		case in == 0 && (r == '\'' || r == '"'):
+			in = r
+		case in != 0 && r == in:
+			in = 0
+		case in == 0 && unicode.IsSpace(r):
+			flush()
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if in != 0 {
+		return nil, fmt.Errorf("unterminated %c quote", in)
+	}
+	flush()
+	if len(args) == 0 {
+		return nil, fmt.Errorf("empty command")
+	}
+	return args, nil
+}
+
+func rejectUnsafe(cmd string) error {
+	var (
+		in  rune
+		esc bool
+	)
+	for i, r := range cmd {
+		switch {
+		case esc:
+			esc = false
+			continue
+		case in == '"' && r == '\\':
+			esc = true
+			continue
+		case in == 0 && (r == '\'' || r == '"'):
+			in = r
+			continue
+		case in != 0 && r == in:
+			in = 0
+			continue
+		}
+		if in != 0 {
+			continue
+		}
+		switch r {
+		case '|', '>', '<', '&', ';', '`':
+			return fmt.Errorf("disallowed shell metachar %q at position %d", r, i)
+		case '\n', '\r':
+			return fmt.Errorf("newline in command at position %d", i)
+		case '$':
+			if i+1 < len(cmd) && cmd[i+1] == '(' {
+				return fmt.Errorf("command substitution $( at position %d", i)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What this fixes

**1. `--safe-mode` was completely broken** (`cli/scan.go`)
The flag was parsed but immediately discarded (`_ = safeMode`). The executor's
`WithSafeMode()` method existed and had tests, but nothing connected them.
Added `SafeMode bool` to `CampaignConfig` and wired it through both
`runner.Run` and `runner.RunSwarm`.

**2. Safe-mode missed tokens inside quoted arguments** (`executor.go`)
The destructive-token check did an exact map lookup per argv token.
A command like `curl example.com -d 'drop table users'` parsed the quoted
section as a single token `"drop table users"`, which never matched `"drop"`.
`TestSafeMode_RejectsDestructiveTokens` was failing in the existing suite.
Fixed by scanning `strings.Fields(part)` so every word inside a quoted
argument is individually checked.

**3. `DefaultCleanupExec` used `sh -c`** (`pipeline/cleanup_memory.go`)
LLM-generated cleanup commands were passed directly to `/bin/sh -c`, meaning
a prompt-injected payload could abuse pipes, redirects, or command
substitution. Replaced with the same `shellsafe.Parse` + `exec.CommandContext`
approach the exploit executor already uses.

**4. Shared parser extracted to `internal/shellsafe`**
Both the exploit executor and the cleanup executor need the same safe parser.
Extracted to a single package so a future fix to one automatically covers both.

**5. REST API had no authentication and wildcard CORS** (`api/server.go`)
Added opt-in `server.api_key` middleware (skips `/health` for probes) and
made CORS origins configurable via `server.cors_origins` instead of `"*"`.
Both fields are documented in `config.example.yaml`.