### PR TITLE
chore(lint): fix formatting, imports and spelling

### DIFF
--- a/cli/campaign.go
+++ b/cli/campaign.go
@@ -91,10 +91,10 @@ var campaignStopCmd = &cobra.Command{
 }
 
 var campaignExploreCmd = &cobra.Command{
-	Use:   "explore <id>",
-	Short: "Interactive attack surface explorer (TUI)",
-	Long:  `Browse discovered subdomains, hosts, ports, services, and findings interactively.`,
-	Args:  cobra.ExactArgs(1),
+	Use:     "explore <id>",
+	Short:   "Interactive attack surface explorer (TUI)",
+	Long:    `Browse discovered subdomains, hosts, ports, services, and findings interactively.`,
+	Args:    cobra.ExactArgs(1),
 	Example: "  pentestswarm campaign explore abc-123",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Exploring attack surface for campaign %s...\n", args[0])

--- a/cli/config.go
+++ b/cli/config.go
@@ -16,8 +16,8 @@ var configCmd = &cobra.Command{
 }
 
 var configInitCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Interactive setup wizard — creates config.yaml",
+	Use:     "init",
+	Short:   "Interactive setup wizard — creates config.yaml",
 	Example: "  pentestswarm config init",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		reader := bufio.NewReader(os.Stdin)

--- a/cli/report.go
+++ b/cli/report.go
@@ -26,9 +26,9 @@ reproducibility and prints actionable suggestions for another pass.
 
 Prints score + suggestions only — the draft file is never modified.
 Use it as a 'ready to submit?' check.`,
-	Args: cobra.ExactArgs(1),
+	Args:    cobra.ExactArgs(1),
 	Example: `  pentestswarm report polish ./submissions/sql-injection.md`,
-	RunE: runReportPolish,
+	RunE:    runReportPolish,
 }
 
 func runReportPolish(cmd *cobra.Command, args []string) error {

--- a/cli/scan.go
+++ b/cli/scan.go
@@ -170,8 +170,8 @@ func runScan(cmd *cobra.Command, args []string) error {
 		Format:           format,
 		Provider:         providerOverride,
 		PublishThreshold: publishThreshold,
-		ExplorationBias: explorationBias,
-		Assist:          assist,
+		ExplorationBias:  explorationBias,
+		Assist:           assist,
 	}
 
 	// Event handler for live output

--- a/deploy/metrics/aggregator.go
+++ b/deploy/metrics/aggregator.go
@@ -10,10 +10,10 @@ import (
 
 // Metrics aggregates download counts from all distribution channels.
 type Metrics struct {
-	TotalDownloads int                `json:"total_downloads"`
-	WeeklyTotal    int                `json:"weekly_total"`
-	Channels       map[string]int     `json:"channels"`
-	UpdatedAt      time.Time          `json:"updated_at"`
+	TotalDownloads int            `json:"total_downloads"`
+	WeeklyTotal    int            `json:"weekly_total"`
+	Channels       map[string]int `json:"channels"`
+	UpdatedAt      time.Time      `json:"updated_at"`
 }
 
 // Aggregator polls download counts from all channels.
@@ -67,7 +67,9 @@ func (a *Aggregator) fetchNPM() int {
 	}
 	defer resp.Body.Close()
 
-	var result struct{ Downloads int `json:"downloads"` }
+	var result struct {
+		Downloads int `json:"downloads"`
+	}
 	json.NewDecoder(resp.Body).Decode(&result)
 	return result.Downloads
 }
@@ -79,7 +81,9 @@ func (a *Aggregator) fetchDockerHub() int {
 	}
 	defer resp.Body.Close()
 
-	var result struct{ PullCount int `json:"pull_count"` }
+	var result struct {
+		PullCount int `json:"pull_count"`
+	}
 	json.NewDecoder(resp.Body).Decode(&result)
 	return result.PullCount
 }

--- a/internal/agent/classifier/scorer.go
+++ b/internal/agent/classifier/scorer.go
@@ -10,14 +10,14 @@ import (
 
 // CVSSComponents holds parsed CVSS v3.1 vector components.
 type CVSSComponents struct {
-	AttackVector          string  // N, A, L, P
-	AttackComplexity      string  // L, H
-	PrivilegesRequired    string  // N, L, H
-	UserInteraction       string  // N, R
-	Scope                 string  // U, C
-	ConfidentialityImpact string  // N, L, H
-	IntegrityImpact       string  // N, L, H
-	AvailabilityImpact    string  // N, L, H
+	AttackVector          string // N, A, L, P
+	AttackComplexity      string // L, H
+	PrivilegesRequired    string // N, L, H
+	UserInteraction       string // N, R
+	Scope                 string // U, C
+	ConfidentialityImpact string // N, L, H
+	IntegrityImpact       string // N, L, H
+	AvailabilityImpact    string // N, L, H
 }
 
 // ScoringContext provides additional context for CVSS adjustment.

--- a/internal/agent/exploit/agent.go
+++ b/internal/agent/exploit/agent.go
@@ -54,10 +54,10 @@ func (e *ExploitAgent) BuildPlan(ctx context.Context, findings pipeline.Classifi
 	if err != nil {
 		// Fall back to rule-based chains only
 		return &pipeline.AttackPlan{
-			ID:         uuid.New(),
-			Paths:      ruleChains,
-			Reasoning:  "LLM unavailable — using rule-based chains only",
-			CreatedAt:  time.Now(),
+			ID:        uuid.New(),
+			Paths:     ruleChains,
+			Reasoning: "LLM unavailable — using rule-based chains only",
+			CreatedAt: time.Now(),
 		}, nil
 	}
 
@@ -95,7 +95,7 @@ func (e *ExploitAgent) AdaptPlan(ctx context.Context, plan *pipeline.AttackPlan,
 		SystemPrompt: "You are a penetration testing strategist. Given the current attack plan and the latest execution result, decide: continue on the current path, pivot to an alternative, or adjust the approach. Think in <think> tags, then output the updated plan as JSON.",
 		Messages: []llm.Message{
 			{
-				Role: "user",
+				Role:    "user",
 				Content: fmt.Sprintf("Current Plan:\n%s\n\nLatest Result:\n%s", string(planJSON), string(resultJSON)),
 			},
 		},

--- a/internal/agent/report/dedup/dedup.go
+++ b/internal/agent/report/dedup/dedup.go
@@ -18,10 +18,10 @@ import "strings"
 // Prior is a minimal record of a past submission — just enough for
 // title-based matching. Callers map platform-specific shapes onto this.
 type Prior struct {
-	ID      string
-	Title   string
-	Target  string // optional; if set, we boost similarity when it matches
-	State   string // optional state, e.g. "duplicate", "resolved"
+	ID     string
+	Title  string
+	Target string // optional; if set, we boost similarity when it matches
+	State  string // optional state, e.g. "duplicate", "resolved"
 }
 
 // Match is a ranked hit: (the prior report, similarity 0..1).

--- a/internal/agent/report/evidence/evidence.go
+++ b/internal/agent/report/evidence/evidence.go
@@ -1,4 +1,4 @@
-// Package evidence captures report-ready artefacts from a finding's
+// Package evidence captures report-ready artifacts from a finding's
 // Reproduction block:
 //
 //   - .http files: the raw HTTP request is written to disk so the
@@ -23,7 +23,7 @@ import (
 	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/pipeline"
 )
 
-// Capture writes every available artefact for a finding into outDir
+// Capture writes every available artifact for a finding into outDir
 // and returns the paths it produced (so the report template can link
 // to them by relative path). Missing tools / empty Reproduction are
 // non-fatal — the researcher still gets whatever we could gather.

--- a/internal/agent/report/qualitygate/gate.go
+++ b/internal/agent/report/qualitygate/gate.go
@@ -19,12 +19,12 @@ import (
 
 // Report is the rubric result.
 type Report struct {
-	OverallScore      float64  `json:"overall_score"`      // 0-10
-	ClarityScore      float64  `json:"clarity_score"`      // 0-10
-	ImpactScore       float64  `json:"impact_score"`       // 0-10
-	ReproducibilityScore float64 `json:"reproducibility_score"` // 0-10
-	Suggestions       []string `json:"suggestions"`
-	BlockingIssue     string   `json:"blocking_issue,omitempty"` // set when overall < threshold
+	OverallScore         float64  `json:"overall_score"`         // 0-10
+	ClarityScore         float64  `json:"clarity_score"`         // 0-10
+	ImpactScore          float64  `json:"impact_score"`          // 0-10
+	ReproducibilityScore float64  `json:"reproducibility_score"` // 0-10
+	Suggestions          []string `json:"suggestions"`
+	BlockingIssue        string   `json:"blocking_issue,omitempty"` // set when overall < threshold
 }
 
 // Threshold is the pass/fail cutoff. Below this overall score, the

--- a/internal/agent/report/sarif.go
+++ b/internal/agent/report/sarif.go
@@ -35,12 +35,12 @@ func (r *Renderer) ToSARIF(report *pipeline.PentestReport) ([]byte, error) {
 		ruleID := sanitiseRuleID(f.Title)
 		if _, dup := seen[ruleID]; !dup {
 			rules = append(rules, sarifRule{
-				ID:   ruleID,
-				Name: f.Title,
-				ShortDescription: sarifDescription{Text: f.Title},
-				FullDescription:  sarifDescription{Text: fallback(f.Description, f.Title)},
-				Help:             sarifMultiformatHelp{Text: fallback(f.Remediation, "See advisory for remediation."), Markdown: fallback(f.Remediation, "See advisory for remediation.")},
-				HelpURI:          firstReference(f.References),
+				ID:                   ruleID,
+				Name:                 f.Title,
+				ShortDescription:     sarifDescription{Text: f.Title},
+				FullDescription:      sarifDescription{Text: fallback(f.Description, f.Title)},
+				Help:                 sarifMultiformatHelp{Text: fallback(f.Remediation, "See advisory for remediation."), Markdown: fallback(f.Remediation, "See advisory for remediation.")},
+				HelpURI:              firstReference(f.References),
 				DefaultConfiguration: sarifDefaultConfig{Level: severityToLevel(f.Severity)},
 				Properties: map[string]any{
 					"security-severity": fmt.Sprintf("%.1f", f.CVSSScore),
@@ -71,10 +71,10 @@ func (r *Renderer) ToSARIF(report *pipeline.PentestReport) ([]byte, error) {
 		Runs: []sarifRun{{
 			Tool: sarifTool{
 				Driver: sarifDriver{
-					Name:            "Pentest Swarm AI",
-					InformationURI:  "https://github.com/Armur-Ai/Pentest-Swarm-AI",
-					Version:         "0.2",
-					Rules:           rules,
+					Name:           "Pentest Swarm AI",
+					InformationURI: "https://github.com/Armur-Ai/Pentest-Swarm-AI",
+					Version:        "0.2",
+					Rules:          rules,
 				},
 			},
 			Results: results,
@@ -113,14 +113,14 @@ type sarifDriver struct {
 }
 
 type sarifRule struct {
-	ID                   string                `json:"id"`
-	Name                 string                `json:"name"`
-	ShortDescription     sarifDescription      `json:"shortDescription"`
-	FullDescription      sarifDescription      `json:"fullDescription"`
-	Help                 sarifMultiformatHelp  `json:"help"`
-	HelpURI              string                `json:"helpUri,omitempty"`
-	DefaultConfiguration sarifDefaultConfig    `json:"defaultConfiguration"`
-	Properties           map[string]any        `json:"properties,omitempty"`
+	ID                   string               `json:"id"`
+	Name                 string               `json:"name"`
+	ShortDescription     sarifDescription     `json:"shortDescription"`
+	FullDescription      sarifDescription     `json:"fullDescription"`
+	Help                 sarifMultiformatHelp `json:"help"`
+	HelpURI              string               `json:"helpUri,omitempty"`
+	DefaultConfiguration sarifDefaultConfig   `json:"defaultConfiguration"`
+	Properties           map[string]any       `json:"properties,omitempty"`
 }
 
 type sarifDescription struct {

--- a/internal/agent/report/sarif_test.go
+++ b/internal/agent/report/sarif_test.go
@@ -63,15 +63,15 @@ func TestToSARIF_RuleIDSafe(t *testing.T) {
 	r := NewRenderer()
 	out, _ := r.ToSARIF(&pipeline.PentestReport{
 		Findings: []pipeline.ReportFinding{{
-			Title: "Critical -- SQL/SSRF & <Dangerous> payload",
-			Severity: pipeline.SeverityHigh,
+			Title:              "Critical -- SQL/SSRF & <Dangerous> payload",
+			Severity:           pipeline.SeverityHigh,
 			AffectedComponents: []string{"x"},
 		}},
 	})
 	body := string(out)
 	// Rule id must be ascii lowercase + hyphens + "/" namespace.
 	if !strings.Contains(body, `"id": "pentestswarm/critical-sql-ssrf-dangerous-payload"`) {
-		t.Fatalf("rule id not sanitised correctly in:\n%s", body)
+		t.Fatalf("rule id not sanitized correctly in:\n%s", body)
 	}
 }
 

--- a/internal/agent/report/submission.go
+++ b/internal/agent/report/submission.go
@@ -48,7 +48,7 @@ func BuildSubmissionView(f pipeline.ReportFinding, cf *pipeline.ClassifiedFindin
 	}
 	v.Summary = fallbackStr(f.Description, "Automated scanner detected a vulnerability on "+v.Target+".")
 	v.Impact = fallbackStr(inferImpact(f.Severity), "See severity rating.")
-	v.Remediation = fallbackStr(f.Remediation, "Apply vendor patch / disable affected feature / sanitise input per vendor guidance.")
+	v.Remediation = fallbackStr(f.Remediation, "Apply vendor patch / disable affected feature / sanitize input per vendor guidance.")
 	if cf != nil {
 		v.CVEIDs = cf.CVEIDs
 		v.AttackCategory = cf.AttackCategory

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -33,10 +33,10 @@ type Server struct {
 
 // CampaignState holds in-memory state for a running campaign.
 type CampaignState struct {
-	Campaign pipeline.Campaign          `json:"campaign"`
-	Events   []pipeline.CampaignEvent   `json:"events"`
+	Campaign pipeline.Campaign            `json:"campaign"`
+	Events   []pipeline.CampaignEvent     `json:"events"`
 	Findings []pipeline.ClassifiedFinding `json:"findings"`
-	Cancel   context.CancelFunc         `json:"-"`
+	Cancel   context.CancelFunc           `json:"-"`
 }
 
 // CreateCampaignRequest is the request body for creating a campaign.
@@ -97,7 +97,7 @@ func (s *Server) registerRoutes() {
 	api.Post("/campaigns/:id/start", s.startCampaign)
 	api.Post("/campaigns/:id/stop", s.stopCampaign)
 	api.Get("/campaigns/:id/findings", s.getCampaignFindings)
-	api.Get("/campaigns/:id/events", s.getCampaignEvents)       // HTTP polling
+	api.Get("/campaigns/:id/events", s.getCampaignEvents)          // HTTP polling
 	api.Get("/campaigns/:id/ws", websocket.New(s.handleWebSocket)) // WebSocket
 
 	api.Get("/models", s.listModels)
@@ -323,11 +323,11 @@ func (s *Server) getStats(c *fiber.Ctx) error {
 	active := 0
 	totalFindings := 0
 	bySeverity := map[pipeline.Severity]int{
-		pipeline.SeverityCritical: 0,
-		pipeline.SeverityHigh:     0,
-		pipeline.SeverityMedium:   0,
-		pipeline.SeverityLow:      0,
-		pipeline.SeverityInformational:     0,
+		pipeline.SeverityCritical:      0,
+		pipeline.SeverityHigh:          0,
+		pipeline.SeverityMedium:        0,
+		pipeline.SeverityLow:           0,
+		pipeline.SeverityInformational: 0,
 	}
 	byAgent := map[string]int{}
 

--- a/internal/asm/diff.go
+++ b/internal/asm/diff.go
@@ -6,11 +6,11 @@ import (
 
 // AssetDiff represents changes between two attack surface snapshots.
 type AssetDiff struct {
-	NewSubdomains      []string             `json:"new_subdomains"`
-	RemovedSubdomains  []string             `json:"removed_subdomains"`
-	NewPorts           map[string][]int     `json:"new_ports"`
-	ClosedPorts        map[string][]int     `json:"closed_ports"`
-	NewEndpoints       []string             `json:"new_endpoints"`
+	NewSubdomains       []string             `json:"new_subdomains"`
+	RemovedSubdomains   []string             `json:"removed_subdomains"`
+	NewPorts            map[string][]int     `json:"new_ports"`
+	ClosedPorts         map[string][]int     `json:"closed_ports"`
+	NewEndpoints        []string             `json:"new_endpoints"`
 	ChangedTechnologies map[string][2]string `json:"changed_technologies"` // key -> [old, new]
 }
 
@@ -24,8 +24,8 @@ func (d *AssetDiff) IsSignificant() bool {
 // Diff computes the differences between two attack surfaces.
 func Diff(prev, curr *pipeline.AttackSurface) *AssetDiff {
 	diff := &AssetDiff{
-		NewPorts:           make(map[string][]int),
-		ClosedPorts:        make(map[string][]int),
+		NewPorts:            make(map[string][]int),
+		ClosedPorts:         make(map[string][]int),
 		ChangedTechnologies: make(map[string][2]string),
 	}
 

--- a/internal/asm/snapshot.go
+++ b/internal/asm/snapshot.go
@@ -10,8 +10,8 @@ import (
 // SnapshotStore stores attack surface snapshots in memory.
 // In production, this would persist to PostgreSQL.
 type SnapshotStore struct {
-	mu        sync.RWMutex
-	snapshots map[uuid.UUID][]*pipeline.AttackSurface // scopeID -> snapshots (newest last)
+	mu          sync.RWMutex
+	snapshots   map[uuid.UUID][]*pipeline.AttackSurface // scopeID -> snapshots (newest last)
 	maxPerScope int
 }
 

--- a/internal/asm/watcher.go
+++ b/internal/asm/watcher.go
@@ -11,22 +11,22 @@ import (
 
 // WatchedScope defines a scope being continuously monitored.
 type WatchedScope struct {
-	ID        uuid.UUID         `json:"id"`
-	Target    string            `json:"target"`
+	ID        uuid.UUID                `json:"id"`
+	Target    string                   `json:"target"`
 	Scope     pipeline.ScopeDefinition `json:"scope"`
-	Schedule  time.Duration     `json:"schedule"`
-	AuthToken string            `json:"-"`
-	Active    bool              `json:"active"`
-	CreatedAt time.Time         `json:"created_at"`
+	Schedule  time.Duration            `json:"schedule"`
+	AuthToken string                   `json:"-"`
+	Active    bool                     `json:"active"`
+	CreatedAt time.Time                `json:"created_at"`
 }
 
 // ScopeWatcher continuously monitors scopes for asset changes.
 type ScopeWatcher struct {
-	scopes     map[uuid.UUID]*WatchedScope
-	mu         sync.RWMutex
-	onChange   func(scopeID uuid.UUID, diff *AssetDiff)
-	reconFunc  func(ctx context.Context, target string, scope pipeline.ScopeDefinition) (*pipeline.AttackSurface, error)
-	snapStore  *SnapshotStore
+	scopes    map[uuid.UUID]*WatchedScope
+	mu        sync.RWMutex
+	onChange  func(scopeID uuid.UUID, diff *AssetDiff)
+	reconFunc func(ctx context.Context, target string, scope pipeline.ScopeDefinition) (*pipeline.AttackSurface, error)
+	snapStore *SnapshotStore
 }
 
 // NewScopeWatcher creates a new scope watcher.

--- a/internal/bugbounty/dedup.go
+++ b/internal/bugbounty/dedup.go
@@ -8,10 +8,10 @@ import (
 
 // DuplicateResult indicates whether a finding is a potential duplicate.
 type DuplicateResult struct {
-	IsDuplicate bool       `json:"is_duplicate"`
-	Confidence  float64    `json:"confidence"`
+	IsDuplicate bool        `json:"is_duplicate"`
+	Confidence  float64     `json:"confidence"`
 	MatchedSub  *Submission `json:"matched_submission,omitempty"`
-	Reason      string     `json:"reason"`
+	Reason      string      `json:"reason"`
 }
 
 // DuplicateDetector checks findings against previous submissions.

--- a/internal/bugbounty/hackerone.go
+++ b/internal/bugbounty/hackerone.go
@@ -11,20 +11,20 @@ import (
 
 // BugBountyProgram represents a bug bounty program from any platform.
 type BugBountyProgram struct {
-	Handle      string       `json:"handle"`
-	Name        string       `json:"name"`
-	Platform    string       `json:"platform"` // hackerone, bugcrowd
-	Policy      string       `json:"policy"`
-	InScope     []ScopeAsset `json:"in_scope"`
-	OutOfScope  []ScopeAsset `json:"out_of_scope"`
+	Handle     string       `json:"handle"`
+	Name       string       `json:"name"`
+	Platform   string       `json:"platform"` // hackerone, bugcrowd
+	Policy     string       `json:"policy"`
+	InScope    []ScopeAsset `json:"in_scope"`
+	OutOfScope []ScopeAsset `json:"out_of_scope"`
 }
 
 // ScopeAsset represents a single scoped asset.
 type ScopeAsset struct {
-	AssetType        string `json:"asset_type"` // URL, domain, IP, app
-	Identifier       string `json:"identifier"`
-	EligibleForBounty bool  `json:"eligible_for_bounty"`
-	MaxSeverity      string `json:"max_severity,omitempty"`
+	AssetType         string `json:"asset_type"` // URL, domain, IP, app
+	Identifier        string `json:"identifier"`
+	EligibleForBounty bool   `json:"eligible_for_bounty"`
+	MaxSeverity       string `json:"max_severity,omitempty"`
 }
 
 // Submission represents a previously submitted report.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,12 +96,12 @@ type AgentsConfig struct {
 }
 
 type ToolsConfig struct {
-	DefaultTimeout int            `mapstructure:"default_timeout"` // seconds
-	Subfinder      SubfinderOpts  `mapstructure:"subfinder"`
-	Httpx          HttpxOpts      `mapstructure:"httpx"`
-	Nuclei         NucleiOpts     `mapstructure:"nuclei"`
-	Naabu          NaabuOpts      `mapstructure:"naabu"`
-	Katana         KatanaOpts     `mapstructure:"katana"`
+	DefaultTimeout int           `mapstructure:"default_timeout"` // seconds
+	Subfinder      SubfinderOpts `mapstructure:"subfinder"`
+	Httpx          HttpxOpts     `mapstructure:"httpx"`
+	Nuclei         NucleiOpts    `mapstructure:"nuclei"`
+	Naabu          NaabuOpts     `mapstructure:"naabu"`
+	Katana         KatanaOpts    `mapstructure:"katana"`
 }
 
 type SubfinderOpts struct {
@@ -179,7 +179,7 @@ type SlackConfig struct {
 }
 
 type LoggingConfig struct {
-	Level  string `mapstructure:"level"` // debug, info, warn, error
+	Level  string `mapstructure:"level"`  // debug, info, warn, error
 	Format string `mapstructure:"format"` // json, console
 }
 

--- a/internal/engine/swarm_runner.go
+++ b/internal/engine/swarm_runner.go
@@ -7,9 +7,9 @@ import (
 
 	classifierpkg "github.com/Armur-Ai/Pentest-Swarm-AI/internal/agent/classifier"
 	exploitpkg "github.com/Armur-Ai/Pentest-Swarm-AI/internal/agent/exploit"
+	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/agent/prompts"
 	reconpkg "github.com/Armur-Ai/Pentest-Swarm-AI/internal/agent/recon"
 	reportpkg "github.com/Armur-Ai/Pentest-Swarm-AI/internal/agent/report"
-	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/agent/prompts"
 	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/llm"
 	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/pipeline"
 	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/scope"
@@ -27,7 +27,7 @@ import (
 // It is intentionally API-compatible with Run so the CLI can flip between
 // them via --swarm. The swarm path terminates via two conditions:
 //
-//   - the campaign context is cancelled (SIGINT, deadline, etc.), OR
+//   - the campaign context is canceled (SIGINT, deadline, etc.), OR
 //   - the per-campaign time budget elapses, after which the runner writes
 //     CAMPAIGN_COMPLETE and waits for the report agent to finish.
 //

--- a/internal/integrations/burp/client.go
+++ b/internal/integrations/burp/client.go
@@ -27,7 +27,7 @@ type Client struct {
 	apiKey   string // optional; Burp MCP can require a bearer token
 }
 
-// Config customises a Client.
+// Config customizes a Client.
 type Config struct {
 	Endpoint string        // default http://127.0.0.1:9100/mcp
 	APIKey   string        // optional bearer
@@ -115,10 +115,10 @@ type ContentBlock struct {
 // Canonical Burp MCP tool names. Keep these up-to-date with the Burp
 // MCP release notes — PortSwigger adds tools periodically.
 const (
-	ToolSiteMap    = "burp_sitemap"      // enumerate discovered URLs in the site map
-	ToolActiveScan = "burp_active_scan"  // start an active scan on a URL or scope
-	ToolScanStatus = "burp_scan_status"  // poll an existing scan
-	ToolGetIssues  = "burp_get_issues"   // retrieve scan issues
+	ToolSiteMap      = "burp_sitemap"       // enumerate discovered URLs in the site map
+	ToolActiveScan   = "burp_active_scan"   // start an active scan on a URL or scope
+	ToolScanStatus   = "burp_scan_status"   // poll an existing scan
+	ToolGetIssues    = "burp_get_issues"    // retrieve scan issues
 	ToolProxyHistory = "burp_proxy_history" // recent proxy events
 )
 

--- a/internal/integrations/jira.go
+++ b/internal/integrations/jira.go
@@ -60,7 +60,9 @@ func (j *JiraClient) CreateIssue(ctx context.Context, finding pipeline.Classifie
 	}
 	defer resp.Body.Close()
 
-	var result struct{ Key string `json:"key"` }
+	var result struct {
+		Key string `json:"key"`
+	}
 	json.NewDecoder(resp.Body).Decode(&result)
 
 	return result.Key, nil

--- a/internal/integrations/jira/client.go
+++ b/internal/integrations/jira/client.go
@@ -19,23 +19,23 @@ import (
 
 // Client talks to a Jira Cloud or Server instance.
 type Client struct {
-	base        string
-	user        string
-	token       string
-	project     string
-	issueType   string
-	priorities  map[pipeline.Severity]string
-	http        *http.Client
+	base       string
+	user       string
+	token      string
+	project    string
+	issueType  string
+	priorities map[pipeline.Severity]string
+	http       *http.Client
 }
 
-// Config customises a Client.
+// Config customizes a Client.
 type Config struct {
-	URL        string                          // https://your-domain.atlassian.net
+	URL        string // https://your-domain.atlassian.net
 	Username   string
 	APIToken   string
-	Project    string                          // project key, e.g. SEC
-	IssueType  string                          // default Bug
-	Priorities map[pipeline.Severity]string    // optional override
+	Project    string                       // project key, e.g. SEC
+	IssueType  string                       // default Bug
+	Priorities map[pipeline.Severity]string // optional override
 	Timeout    time.Duration
 }
 
@@ -75,12 +75,12 @@ func NewClient(cfg Config) *Client {
 func (c *Client) CreateIssue(ctx context.Context, f pipeline.ClassifiedFinding) (string, error) {
 	body := map[string]any{
 		"fields": map[string]any{
-			"project":   map[string]string{"key": c.project},
-			"issuetype": map[string]string{"name": c.issueType},
-			"priority":  map[string]string{"name": c.priorities[f.Severity]},
-			"summary":   fmt.Sprintf("[%s] %s", strings.ToUpper(string(f.Severity)), f.Title),
+			"project":     map[string]string{"key": c.project},
+			"issuetype":   map[string]string{"name": c.issueType},
+			"priority":    map[string]string{"name": c.priorities[f.Severity]},
+			"summary":     fmt.Sprintf("[%s] %s", strings.ToUpper(string(f.Severity)), f.Title),
 			"description": buildDescription(f),
-			"labels":    []string{"pentest-swarm-ai", string(f.Severity), sanitiseLabel(f.AttackCategory)},
+			"labels":      []string{"pentest-swarm-ai", string(f.Severity), sanitiseLabel(f.AttackCategory)},
 		},
 	}
 	buf, _ := json.Marshal(body)

--- a/internal/integrations/metasploit/client.go
+++ b/internal/integrations/metasploit/client.go
@@ -37,7 +37,7 @@ type Client struct {
 
 // Config customises a Client.
 type Config struct {
-	Endpoint string        // default https://127.0.0.1:55553/api/
+	Endpoint string // default https://127.0.0.1:55553/api/
 	User     string
 	Pass     string
 	Timeout  time.Duration // default 30s
@@ -119,16 +119,16 @@ func (c *Client) ListSessions(ctx context.Context) (map[string]Session, error) {
 
 // Session is a live msfrpcd session.
 type Session struct {
-	Type     string `json:"type"`
-	TunnelLP string `json:"tunnel_local"`
-	TunnelPP string `json:"tunnel_peer"`
-	ViaEx    string `json:"via_exploit"`
-	ViaPay   string `json:"via_payload"`
-	Desc     string `json:"desc"`
-	Info     string `json:"info"`
-	Workspace string `json:"workspace"`
+	Type        string `json:"type"`
+	TunnelLP    string `json:"tunnel_local"`
+	TunnelPP    string `json:"tunnel_peer"`
+	ViaEx       string `json:"via_exploit"`
+	ViaPay      string `json:"via_payload"`
+	Desc        string `json:"desc"`
+	Info        string `json:"info"`
+	Workspace   string `json:"workspace"`
 	SessionHost string `json:"session_host"`
-	SessionPort int   `json:"session_port"`
+	SessionPort int    `json:"session_port"`
 	TargetHost  string `json:"target_host"`
 	Username    string `json:"username"`
 	UUID        string `json:"uuid"`

--- a/internal/integrations/siem.go
+++ b/internal/integrations/siem.go
@@ -51,13 +51,13 @@ func FormatSARIF(findings []pipeline.ClassifiedFinding) ([]byte, error) {
 // FormatSTIX converts a finding to STIX 2.1 vulnerability object.
 func FormatSTIX(finding pipeline.ClassifiedFinding) ([]byte, error) {
 	stix := map[string]any{
-		"type":        "vulnerability",
-		"spec_version": "2.1",
-		"id":          fmt.Sprintf("vulnerability--%s", finding.ID),
-		"created":     finding.ClassifiedAt.Format(time.RFC3339),
-		"modified":    time.Now().Format(time.RFC3339),
-		"name":        finding.Title,
-		"description": finding.Description,
+		"type":                "vulnerability",
+		"spec_version":        "2.1",
+		"id":                  fmt.Sprintf("vulnerability--%s", finding.ID),
+		"created":             finding.ClassifiedAt.Format(time.RFC3339),
+		"modified":            time.Now().Format(time.RFC3339),
+		"name":                finding.Title,
+		"description":         finding.Description,
 		"external_references": buildExternalRefs(finding),
 	}
 

--- a/internal/integrations/slack/client.go
+++ b/internal/integrations/slack/client.go
@@ -31,11 +31,11 @@ type Client struct {
 	threads map[string]string // campaign_id -> thread_ts
 }
 
-// Config customises a Client.
+// Config customizes a Client.
 type Config struct {
-	WebhookURL string        // https://hooks.slack.com/services/...
-	BotToken   string        // xoxb-...
-	Channel    string        // e.g. #security (only used with BotToken)
+	WebhookURL string // https://hooks.slack.com/services/...
+	BotToken   string // xoxb-...
+	Channel    string // e.g. #security (only used with BotToken)
 	Timeout    time.Duration
 }
 
@@ -54,7 +54,7 @@ func NewClient(cfg Config) *Client {
 }
 
 // PostFinding sends a formatted finding message. Blocks format is used
-// so severity colour + CVSS render cleanly in Slack.
+// so severity color + CVSS render cleanly in Slack.
 func (c *Client) PostFinding(ctx context.Context, campaignID string, f pipeline.ClassifiedFinding) error {
 	text := fmt.Sprintf(":rotating_light: *%s* — %s (CVSS %.1f)",
 		strings.ToUpper(string(f.Severity)), f.Title, f.CVSSScore)

--- a/internal/integrations/zap/client.go
+++ b/internal/integrations/zap/client.go
@@ -27,7 +27,7 @@ type Client struct {
 
 // Config customises a Client.
 type Config struct {
-	Endpoint string        // default http://127.0.0.1:8090
+	Endpoint string // default http://127.0.0.1:8090
 	APIKey   string
 	Timeout  time.Duration
 }
@@ -112,19 +112,19 @@ func (c *Client) Alerts(ctx context.Context, baseURL string) ([]Alert, error) {
 
 // Alert is ZAP's alert shape (a subset; ZAP emits ~40 fields — we track the useful ones).
 type Alert struct {
-	ID         string `json:"id"`
-	PluginID   string `json:"pluginId"`
-	Name       string `json:"name"`
-	Risk       string `json:"risk"`       // High | Medium | Low | Informational
-	Confidence string `json:"confidence"` // High | Medium | Low | Confirmed
-	URL        string `json:"url"`
-	Param      string `json:"param"`
-	Attack     string `json:"attack"`
-	Evidence   string `json:"evidence"`
+	ID          string `json:"id"`
+	PluginID    string `json:"pluginId"`
+	Name        string `json:"name"`
+	Risk        string `json:"risk"`       // High | Medium | Low | Informational
+	Confidence  string `json:"confidence"` // High | Medium | Low | Confirmed
+	URL         string `json:"url"`
+	Param       string `json:"param"`
+	Attack      string `json:"attack"`
+	Evidence    string `json:"evidence"`
 	Description string `json:"description"`
 	Solution    string `json:"solution"`
-	CWEID      string `json:"cweid"`
-	WASCID     string `json:"wascid"`
+	CWEID       string `json:"cweid"`
+	WASCID      string `json:"wascid"`
 }
 
 // --- transport ---

--- a/internal/integrations/zap/client_test.go
+++ b/internal/integrations/zap/client_test.go
@@ -33,7 +33,7 @@ func fakeZAP(t *testing.T, apiKey string) *httptest.Server {
 					{
 						"id": "1", "pluginId": "40018", "name": "SQL Injection",
 						"risk": "High", "confidence": "Medium",
-						"url":  "https://example.com/?id=1",
+						"url": "https://example.com/?id=1",
 					},
 				},
 			})

--- a/internal/llm/budget.go
+++ b/internal/llm/budget.go
@@ -7,7 +7,7 @@ import (
 
 // BudgetManager tracks token usage and manages context window limits.
 type BudgetManager struct {
-	contextWindow   int
+	contextWindow    int
 	warningThreshold float64 // percentage of context window to warn at (0.8 = 80%)
 	summarizeAt      float64 // percentage to trigger summarization (0.7 = 70%)
 }

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -55,8 +55,8 @@ type ollamaChatRequest struct {
 }
 
 type ollamaChatMessage struct {
-	Role      string          `json:"role"`
-	Content   string          `json:"content"`
+	Role      string           `json:"role"`
+	Content   string           `json:"content"`
 	ToolCalls []ollamaToolCall `json:"tool_calls,omitempty"`
 }
 
@@ -87,13 +87,13 @@ type ollamaToolCallFunction struct {
 
 // ollamaChatResponse is the response body from POST /api/chat.
 type ollamaChatResponse struct {
-	Model     string            `json:"model"`
-	Message   ollamaChatMessage `json:"message"`
-	Done      bool              `json:"done"`
-	DoneReason string           `json:"done_reason"`
-	TotalDuration  int64        `json:"total_duration"`
-	PromptEvalCount   int       `json:"prompt_eval_count"`
-	EvalCount         int       `json:"eval_count"`
+	Model           string            `json:"model"`
+	Message         ollamaChatMessage `json:"message"`
+	Done            bool              `json:"done"`
+	DoneReason      string            `json:"done_reason"`
+	TotalDuration   int64             `json:"total_duration"`
+	PromptEvalCount int               `json:"prompt_eval_count"`
+	EvalCount       int               `json:"eval_count"`
 }
 
 func (o *OllamaProvider) Complete(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {

--- a/internal/llm/pricing.go
+++ b/internal/llm/pricing.go
@@ -78,9 +78,10 @@ func (p Pricing) CostUSD(u Usage) float64 {
 // that'll cost more than the program's average bounty.
 //
 // targetClass is a rough bucket:
-//   "small"  — single subdomain, <= 20 endpoints (e.g. a simple app)
-//   "medium" — typical corporate site, 100-500 endpoints
-//   "large"  — bug-bounty-program-scale, thousands of endpoints
+//
+//	"small"  — single subdomain, <= 20 endpoints (e.g. a simple app)
+//	"medium" — typical corporate site, 100-500 endpoints
+//	"large"  — bug-bounty-program-scale, thousands of endpoints
 func (p Pricing) EstimateUSD(targetClass string) (lowUSD, highUSD float64) {
 	// Token-count ranges are calibrated against internal campaign logs.
 	// Output ratio ~ 0.15 of input is typical for the classifier +

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -82,9 +82,9 @@ type jsonRPCRequest struct {
 }
 
 type jsonRPCResponse struct {
-	JSONRPC string `json:"jsonrpc"`
-	ID      any    `json:"id,omitempty"`
-	Result  any    `json:"result,omitempty"`
+	JSONRPC string        `json:"jsonrpc"`
+	ID      any           `json:"id,omitempty"`
+	Result  any           `json:"result,omitempty"`
 	Error   *jsonRPCError `json:"error,omitempty"`
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -64,7 +64,9 @@ func RegisterDefaultTools(s *Server, cfg *config.Config) {
 		Description: "Run reconnaissance only against a target, returning the discovered attack surface (subdomains, ports, services, technologies).",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"target":{"type":"string","description":"Target to scan"}},"required":["target"]}`),
 		Handler: func(args json.RawMessage) (string, error) {
-			var params struct{ Target string `json:"target"` }
+			var params struct {
+				Target string `json:"target"`
+			}
 			json.Unmarshal(args, &params)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
@@ -117,7 +119,9 @@ func RegisterDefaultTools(s *Server, cfg *config.Config) {
 		Description: "Get the current status of a running penetration test campaign.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"campaign_id":{"type":"string","description":"Campaign UUID"}},"required":["campaign_id"]}`),
 		Handler: func(args json.RawMessage) (string, error) {
-			var params struct{ CampaignID string `json:"campaign_id"` }
+			var params struct {
+				CampaignID string `json:"campaign_id"`
+			}
 			json.Unmarshal(args, &params)
 			return fmt.Sprintf("Campaign %s: check status via API at http://localhost:8080/api/v1/campaigns/%s", params.CampaignID, params.CampaignID), nil
 		},

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -7,13 +7,13 @@ import (
 
 // MemoryEntry is a learned pattern from a previous campaign.
 type MemoryEntry struct {
-	ID          string    `json:"id"`
-	Category    string    `json:"category"` // tech_stack, attack_chain, false_positive, timing
-	Pattern     string    `json:"pattern"`
-	Confidence  float64   `json:"confidence"`
-	UsageCount  int       `json:"usage_count"`
-	LastUsed    time.Time `json:"last_used"`
-	CreatedAt   time.Time `json:"created_at"`
+	ID         string    `json:"id"`
+	Category   string    `json:"category"` // tech_stack, attack_chain, false_positive, timing
+	Pattern    string    `json:"pattern"`
+	Confidence float64   `json:"confidence"`
+	UsageCount int       `json:"usage_count"`
+	LastUsed   time.Time `json:"last_used"`
+	CreatedAt  time.Time `json:"created_at"`
 }
 
 // MemoryStore persists learned patterns across campaigns.

--- a/internal/pipeline/context.go
+++ b/internal/pipeline/context.go
@@ -36,18 +36,18 @@ const (
 
 // Campaign is the top-level entity for a penetration test run.
 type Campaign struct {
-	ID          uuid.UUID      `json:"id" db:"id"`
-	Name        string         `json:"name" db:"name"`
-	Target      string         `json:"target" db:"target"`
-	Objective   string         `json:"objective" db:"objective"`
-	Status      CampaignStatus `json:"status" db:"status"`
-	Mode        CampaignMode   `json:"mode" db:"mode"`
+	ID          uuid.UUID       `json:"id" db:"id"`
+	Name        string          `json:"name" db:"name"`
+	Target      string          `json:"target" db:"target"`
+	Objective   string          `json:"objective" db:"objective"`
+	Status      CampaignStatus  `json:"status" db:"status"`
+	Mode        CampaignMode    `json:"mode" db:"mode"`
 	Scope       ScopeDefinition `json:"scope" db:"scope"`
-	AuthToken   string         `json:"-" db:"auth_token"`
-	Provider    string         `json:"provider" db:"provider"`
-	CreatedAt   time.Time      `json:"created_at" db:"created_at"`
-	StartedAt   *time.Time     `json:"started_at,omitempty" db:"started_at"`
-	CompletedAt *time.Time     `json:"completed_at,omitempty" db:"completed_at"`
+	AuthToken   string          `json:"-" db:"auth_token"`
+	Provider    string          `json:"provider" db:"provider"`
+	CreatedAt   time.Time       `json:"created_at" db:"created_at"`
+	StartedAt   *time.Time      `json:"started_at,omitempty" db:"started_at"`
+	CompletedAt *time.Time      `json:"completed_at,omitempty" db:"completed_at"`
 }
 
 // ScopeDefinition defines the allowed targets for a campaign.
@@ -75,7 +75,7 @@ func (s *ScopeDefinition) Scan(src any) error {
 // CampaignEvent is an append-only audit log entry.
 type CampaignEvent struct {
 	ID         uuid.UUID       `json:"id" db:"id"`
-	CampaignID uuid.UUID      `json:"campaign_id" db:"campaign_id"`
+	CampaignID uuid.UUID       `json:"campaign_id" db:"campaign_id"`
 	Timestamp  time.Time       `json:"timestamp" db:"timestamp"`
 	EventType  EventType       `json:"event_type" db:"event_type"`
 	AgentName  string          `json:"agent_name,omitempty" db:"agent_name"`
@@ -87,14 +87,14 @@ type CampaignEvent struct {
 type EventType string
 
 const (
-	EventThought          EventType = "thought"
-	EventToolCall         EventType = "tool_call"
-	EventToolResult       EventType = "tool_result"
+	EventThought           EventType = "thought"
+	EventToolCall          EventType = "tool_call"
+	EventToolResult        EventType = "tool_result"
 	EventFindingDiscovered EventType = "finding_discovered"
-	EventStateChange      EventType = "state_change"
-	EventStepExecuted     EventType = "step_executed"
-	EventError            EventType = "error"
-	EventMilestone        EventType = "milestone"
+	EventStateChange       EventType = "state_change"
+	EventStepExecuted      EventType = "step_executed"
+	EventError             EventType = "error"
+	EventMilestone         EventType = "milestone"
 )
 
 // Severity levels for findings.

--- a/internal/pipeline/models.go
+++ b/internal/pipeline/models.go
@@ -10,13 +10,13 @@ import (
 
 // AttackSurface is the structured output of the recon phase.
 type AttackSurface struct {
-	CampaignID   uuid.UUID                `json:"campaign_id"`
-	Target       string                   `json:"target"`
-	Subdomains   []SubdomainRecord        `json:"subdomains"`
-	Hosts        []HostRecord             `json:"hosts"`
-	Endpoints    []EndpointRecord         `json:"endpoints"`
-	Technologies map[string]string        `json:"technologies"`
-	CreatedAt    time.Time                `json:"created_at"`
+	CampaignID   uuid.UUID         `json:"campaign_id"`
+	Target       string            `json:"target"`
+	Subdomains   []SubdomainRecord `json:"subdomains"`
+	Hosts        []HostRecord      `json:"hosts"`
+	Endpoints    []EndpointRecord  `json:"endpoints"`
+	Technologies map[string]string `json:"technologies"`
+	CreatedAt    time.Time         `json:"created_at"`
 }
 
 // SubdomainRecord represents a discovered subdomain.
@@ -30,12 +30,12 @@ type SubdomainRecord struct {
 
 // HostRecord represents a discovered host/IP.
 type HostRecord struct {
-	IP        string                   `json:"ip"`
-	Hostnames []string                 `json:"hostnames"`
-	OpenPorts []int                    `json:"open_ports"`
-	Services  map[int]ServiceRecord    `json:"services"`
-	OS        string                   `json:"os,omitempty"`
-	Tags      []string                 `json:"tags,omitempty"`
+	IP        string                `json:"ip"`
+	Hostnames []string              `json:"hostnames"`
+	OpenPorts []int                 `json:"open_ports"`
+	Services  map[int]ServiceRecord `json:"services"`
+	OS        string                `json:"os,omitempty"`
+	Tags      []string              `json:"tags,omitempty"`
 }
 
 // ServiceRecord represents a service running on a port.
@@ -50,13 +50,13 @@ type ServiceRecord struct {
 
 // HTTPDetails contains HTTP-specific information about an endpoint.
 type HTTPDetails struct {
-	URL            string            `json:"url"`
-	StatusCode     int               `json:"status_code"`
-	Title          string            `json:"title,omitempty"`
-	Server         string            `json:"server,omitempty"`
-	Technologies   []string          `json:"technologies,omitempty"`
-	Headers        map[string]string `json:"headers,omitempty"`
-	ResponseBodyHash string          `json:"response_body_hash,omitempty"`
+	URL              string            `json:"url"`
+	StatusCode       int               `json:"status_code"`
+	Title            string            `json:"title,omitempty"`
+	Server           string            `json:"server,omitempty"`
+	Technologies     []string          `json:"technologies,omitempty"`
+	Headers          map[string]string `json:"headers,omitempty"`
+	ResponseBodyHash string            `json:"response_body_hash,omitempty"`
 }
 
 // EndpointRecord represents a discovered web endpoint.
@@ -142,10 +142,10 @@ type Evidence struct {
 
 // ClassifiedFindingSet is the output of the classifier agent.
 type ClassifiedFindingSet struct {
-	CampaignID uuid.UUID            `json:"campaign_id"`
-	Findings   []ClassifiedFinding  `json:"findings"`
+	CampaignID uuid.UUID             `json:"campaign_id"`
+	Findings   []ClassifiedFinding   `json:"findings"`
 	Summary    ClassificationSummary `json:"summary"`
-	CreatedAt  time.Time            `json:"created_at"`
+	CreatedAt  time.Time             `json:"created_at"`
 }
 
 // ClassificationSummary provides aggregate stats about classified findings.
@@ -153,7 +153,7 @@ type ClassificationSummary struct {
 	TotalFindings int              `json:"total_findings"`
 	BySeverity    map[Severity]int `json:"by_severity"`
 	TopCategories []string         `json:"top_categories"`
-	FilteredAsFP  int             `json:"filtered_as_fp"`
+	FilteredAsFP  int              `json:"filtered_as_fp"`
 }
 
 // --- Attack Plan Models ---
@@ -182,14 +182,14 @@ type AttackPath struct {
 
 // AttackStep is a single action in an attack path.
 type AttackStep struct {
-	ID                   uuid.UUID  `json:"id"`
-	Name                 string     `json:"name"`
-	TechniqueID          string     `json:"technique_id,omitempty"` // MITRE ATT&CK
-	Command              string     `json:"command"`
-	ExpectedOutputPattern string   `json:"expected_output_pattern,omitempty"`
-	OnSuccessStepID      *uuid.UUID `json:"on_success_step_id,omitempty"`
-	OnFailureStepID      *uuid.UUID `json:"on_failure_step_id,omitempty"`
-	CleanupCommand       string     `json:"cleanup_command,omitempty"`
+	ID                    uuid.UUID  `json:"id"`
+	Name                  string     `json:"name"`
+	TechniqueID           string     `json:"technique_id,omitempty"` // MITRE ATT&CK
+	Command               string     `json:"command"`
+	ExpectedOutputPattern string     `json:"expected_output_pattern,omitempty"`
+	OnSuccessStepID       *uuid.UUID `json:"on_success_step_id,omitempty"`
+	OnFailureStepID       *uuid.UUID `json:"on_failure_step_id,omitempty"`
+	CleanupCommand        string     `json:"cleanup_command,omitempty"`
 }
 
 // ExecutionResult records the outcome of executing an attack step.
@@ -231,17 +231,17 @@ type PentestReport struct {
 
 // ReportFinding is a finding formatted for the report.
 type ReportFinding struct {
-	ID                 uuid.UUID `json:"id"`
-	Title              string    `json:"title"`
-	Severity           Severity  `json:"severity"`
-	CVSSScore          float64   `json:"cvss_score"`
-	CVSSVector         string    `json:"cvss_vector,omitempty"`
-	Description        string    `json:"description"`
+	ID                 uuid.UUID  `json:"id"`
+	Title              string     `json:"title"`
+	Severity           Severity   `json:"severity"`
+	CVSSScore          float64    `json:"cvss_score"`
+	CVSSVector         string     `json:"cvss_vector,omitempty"`
+	Description        string     `json:"description"`
 	Evidence           []Evidence `json:"evidence"`
-	AffectedComponents []string  `json:"affected_components"`
-	Remediation        string    `json:"remediation"`
-	References         []string  `json:"references,omitempty"`
-	ProofOfConcept     string    `json:"proof_of_concept,omitempty"`
+	AffectedComponents []string   `json:"affected_components"`
+	Remediation        string     `json:"remediation"`
+	References         []string   `json:"references,omitempty"`
+	ProofOfConcept     string     `json:"proof_of_concept,omitempty"`
 }
 
 // RiskSummary provides an overview of risk levels.

--- a/internal/pipeline/nvdcheck/nvdcheck.go
+++ b/internal/pipeline/nvdcheck/nvdcheck.go
@@ -42,7 +42,7 @@ type Entry struct {
 	FetchedAt  time.Time `json:"fetched_at"`
 }
 
-// Config customises a Client.
+// Config customizes a Client.
 type Config struct {
 	APIKey   string        // optional NVD API key — https://nvd.nist.gov/developers/request-an-api-key
 	CacheDir string        // default: ~/.pentestswarm/nvd-cache

--- a/internal/pipeline/statemachine.go
+++ b/internal/pipeline/statemachine.go
@@ -76,14 +76,14 @@ func (sm *StateMachine) Transition(newStatus CampaignStatus) error {
 }
 
 // Start begins the campaign.
-func (sm *StateMachine) Start() error     { return sm.Transition(StatusInitializing) }
-func (sm *StateMachine) BeginRecon() error { return sm.Transition(StatusRecon) }
+func (sm *StateMachine) Start() error            { return sm.Transition(StatusInitializing) }
+func (sm *StateMachine) BeginRecon() error       { return sm.Transition(StatusRecon) }
 func (sm *StateMachine) BeginClassifying() error { return sm.Transition(StatusClassifying) }
 func (sm *StateMachine) BeginPlanning() error    { return sm.Transition(StatusPlanning) }
 func (sm *StateMachine) BeginExecuting() error   { return sm.Transition(StatusExecuting) }
 func (sm *StateMachine) BeginAdapting() error    { return sm.Transition(StatusAdapting) }
 func (sm *StateMachine) BeginReporting() error   { return sm.Transition(StatusReporting) }
-func (sm *StateMachine) Complete() error          { return sm.Transition(StatusComplete) }
+func (sm *StateMachine) Complete() error         { return sm.Transition(StatusComplete) }
 func (sm *StateMachine) Fail(reason string) error {
 	err := sm.Transition(StatusFailed)
 	if err == nil && sm.onEvent != nil {

--- a/internal/plugins/overlay_test.go
+++ b/internal/plugins/overlay_test.go
@@ -54,7 +54,7 @@ func TestOverlay_VariablesOverlayWinsPerKey(t *testing.T) {
 		"timeout": {Type: "int", Default: "300"},
 	}}
 	o := &Playbook{Variables: map[string]Variable{
-		"timeout": {Type: "int", Default: "60"},  // overrides
+		"timeout": {Type: "int", Default: "60"},         // overrides
 		"focus":   {Type: "string", Default: "graphql"}, // adds
 	}}
 	got := Overlay(b, o)
@@ -76,7 +76,7 @@ func TestOverlay_PhasesReplaceByName(t *testing.T) {
 	}}
 	o := &Playbook{Phases: []Phase{
 		{Name: "recon", Tools: []ToolConfig{{Name: "amass"}}}, // replaces
-		{Name: "report"},                                      // appends
+		{Name: "report"}, // appends
 	}}
 	got := Overlay(b, o)
 	if len(got.Phases) != 3 {

--- a/internal/plugins/types.go
+++ b/internal/plugins/types.go
@@ -2,14 +2,14 @@ package plugins
 
 // Playbook defines a YAML-based attack playbook.
 type Playbook struct {
-	Name        string            `yaml:"name" json:"name"`
-	Description string            `yaml:"description" json:"description"`
-	Author      PlaybookAuthor    `yaml:"author" json:"author"`
-	Version     string            `yaml:"version" json:"version"`
-	Tags        []string          `yaml:"tags" json:"tags"`
+	Name        string              `yaml:"name" json:"name"`
+	Description string              `yaml:"description" json:"description"`
+	Author      PlaybookAuthor      `yaml:"author" json:"author"`
+	Version     string              `yaml:"version" json:"version"`
+	Tags        []string            `yaml:"tags" json:"tags"`
 	Variables   map[string]Variable `yaml:"variables" json:"variables"`
-	Phases      []Phase           `yaml:"phases" json:"phases"`
-	Include     []string          `yaml:"include,omitempty" json:"include,omitempty"`
+	Phases      []Phase             `yaml:"phases" json:"phases"`
+	Include     []string            `yaml:"include,omitempty" json:"include,omitempty"`
 }
 
 // PlaybookAuthor identifies who created the playbook.
@@ -43,12 +43,12 @@ type ToolConfig struct {
 
 // CustomToolDef defines an external tool via YAML.
 type CustomToolDef struct {
-	Name          string            `yaml:"name" json:"name"`
-	Description   string            `yaml:"description" json:"description"`
-	Command       string            `yaml:"command" json:"command"`
-	OutputFormat  string            `yaml:"output_format" json:"output_format"`
-	FindingParser FindingParserDef  `yaml:"finding_parser" json:"finding_parser"`
-	ScopeCheck    bool              `yaml:"scope_check" json:"scope_check"`
+	Name          string           `yaml:"name" json:"name"`
+	Description   string           `yaml:"description" json:"description"`
+	Command       string           `yaml:"command" json:"command"`
+	OutputFormat  string           `yaml:"output_format" json:"output_format"`
+	FindingParser FindingParserDef `yaml:"finding_parser" json:"finding_parser"`
+	ScopeCheck    bool             `yaml:"scope_check" json:"scope_check"`
 }
 
 // FindingParserDef describes how to parse tool output into findings.
@@ -60,9 +60,9 @@ type FindingParserDef struct {
 
 // PlaybookStats tracks community usage.
 type PlaybookStats struct {
-	Name          string `json:"name"`
-	TimesUsed     int    `json:"times_used"`
-	FindingsFound int    `json:"findings_found"`
-	AvgSeverity   string `json:"avg_severity"`
+	Name          string  `json:"name"`
+	TimesUsed     int     `json:"times_used"`
+	FindingsFound int     `json:"findings_found"`
+	AvgSeverity   string  `json:"avg_severity"`
 	Rating        float64 `json:"rating"`
 }

--- a/internal/plugins/validate_test.go
+++ b/internal/plugins/validate_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func minimalOK() *Playbook {
 	return &Playbook{
-		Name:    "demo",
-		Version: "1.0.0",
-		Author:  PlaybookAuthor{Name: "a"},
+		Name:        "demo",
+		Version:     "1.0.0",
+		Author:      PlaybookAuthor{Name: "a"},
 		Description: "demo playbook",
 		Phases: []Phase{
 			{Name: "recon", Tools: []ToolConfig{{Name: "httpx"}}},

--- a/internal/scope/differ.go
+++ b/internal/scope/differ.go
@@ -2,14 +2,14 @@ package scope
 
 import "sort"
 
-// Diff summarises additions + removals + unchanged between two scopes.
-// Callers decide how to render — JSON, coloured terminal, SARIF, etc.
+// Diff summarizes additions + removals + unchanged between two scopes.
+// Callers decide how to render — JSON, colored terminal, SARIF, etc.
 type Diff struct {
-	AddedDomains    []string `json:"added_domains"`
-	RemovedDomains  []string `json:"removed_domains"`
-	AddedCIDRs      []string `json:"added_cidrs"`
-	RemovedCIDRs    []string `json:"removed_cidrs"`
-	Unchanged       int      `json:"unchanged_count"`
+	AddedDomains   []string `json:"added_domains"`
+	RemovedDomains []string `json:"removed_domains"`
+	AddedCIDRs     []string `json:"added_cidrs"`
+	RemovedCIDRs   []string `json:"removed_cidrs"`
+	Unchanged      int      `json:"unchanged_count"`
 }
 
 // HasChanges is true when either side is non-empty — useful for exit codes.

--- a/internal/scope/differ_test.go
+++ b/internal/scope/differ_test.go
@@ -9,7 +9,7 @@ func TestCompare_FindsAddsAndRemoves(t *testing.T) {
 	}
 	cur := ScopeDefinition{
 		AllowedDomains: []string{"api.acme.corp", "shop.acme.corp"}, // -www, +shop
-		AllowedCIDRs:   []string{"10.0.0.0/24", "10.0.1.0/24"},       // +10.0.1.0/24
+		AllowedCIDRs:   []string{"10.0.0.0/24", "10.0.1.0/24"},      // +10.0.1.0/24
 	}
 	d := Compare(prev, cur)
 	if len(d.AddedDomains) != 1 || d.AddedDomains[0] != "shop.acme.corp" {

--- a/internal/scope/importer/hackerone/hackerone.go
+++ b/internal/scope/importer/hackerone/hackerone.go
@@ -1,16 +1,19 @@
 // Package hackerone imports scope from HackerOne programs.
 //
 // HackerOne exposes structured_scopes per program through its API:
-//   GET https://api.hackerone.com/v1/hackers/programs/<slug>/structured_scopes
+//
+//	GET https://api.hackerone.com/v1/hackers/programs/<slug>/structured_scopes
+//
 // Authenticated requests get the full list (including private programs);
 // unauthenticated requests work for public bounty programs.
 //
 // The asset_type field drives how we slot each scope item into our
 // scope.ScopeDefinition:
-//   URL / WILDCARD / DOMAIN → AllowedDomains
-//   CIDR                    → AllowedCIDRs
-//   IP                      → AllowedCIDRs (as /32)
-//   Anything else           → dropped with a DEBUG log (out of our lane)
+//
+//	URL / WILDCARD / DOMAIN → AllowedDomains
+//	CIDR                    → AllowedCIDRs
+//	IP                      → AllowedCIDRs (as /32)
+//	Anything else           → dropped with a DEBUG log (out of our lane)
 package hackerone
 
 import (
@@ -28,10 +31,10 @@ import (
 
 // Client is a thin HackerOne API client.
 type Client struct {
-	http      *http.Client
-	baseURL   string
-	apiUser   string
-	apiToken  string
+	http     *http.Client
+	baseURL  string
+	apiUser  string
+	apiToken string
 }
 
 // Config customises a Client.
@@ -84,10 +87,10 @@ func (c *Client) Import(ctx context.Context, slug string) (*scope.ScopeDefinitio
 	var envelope struct {
 		Data []struct {
 			Attributes struct {
-				AssetIdentifier     string `json:"asset_identifier"`
-				AssetType           string `json:"asset_type"`
-				EligibleForSubmission bool `json:"eligible_for_submission"`
-				EligibleForBounty     bool `json:"eligible_for_bounty"`
+				AssetIdentifier       string `json:"asset_identifier"`
+				AssetType             string `json:"asset_type"`
+				EligibleForSubmission bool   `json:"eligible_for_submission"`
+				EligibleForBounty     bool   `json:"eligible_for_bounty"`
 			} `json:"attributes"`
 		} `json:"data"`
 	}

--- a/internal/scope/importer/importer.go
+++ b/internal/scope/importer/importer.go
@@ -16,7 +16,7 @@ type Importer interface {
 	Platform() string
 
 	// Import fetches the current scope for the program and returns it as
-	// a ScopeDefinition ready to be marshalled into scope.yaml.
+	// a ScopeDefinition ready to be marshaled into scope.yaml.
 	Import(ctx context.Context, programSlug string) (*scope.ScopeDefinition, error)
 }
 

--- a/internal/scope/programterms/programterms_test.go
+++ b/internal/scope/programterms/programterms_test.go
@@ -11,9 +11,9 @@ func TestParse_NoAutomatedScanning(t *testing.T) {
 
 func TestParse_RateLimit(t *testing.T) {
 	cases := map[string]float64{
-		"Please limit your requests to 5 requests per second.":   5.0,
-		"Do not exceed 60 requests per minute.":                  1.0,
-		"Maximum 3600 req/hour for any single endpoint.":         1.0,
+		"Please limit your requests to 5 requests per second.": 5.0,
+		"Do not exceed 60 requests per minute.":                1.0,
+		"Maximum 3600 req/hour for any single endpoint.":       1.0,
 	}
 	for in, want := range cases {
 		got := Parse(in).MaxRequestsPerSecond

--- a/internal/scope/watcher_test.go
+++ b/internal/scope/watcher_test.go
@@ -32,7 +32,7 @@ var yamlMarshal = func(v any) ([]byte, error) {
 }
 
 func TestWatcher_ReloadDetectsDrift(t *testing.T) {
-	// Avoid test-yaml import gymnastics: serialise via a tiny inline marshaller.
+	// Avoid test-yaml import gymnastics: serialize via a tiny inline marshaller.
 	yamlMarshal = func(v any) ([]byte, error) {
 		def := v.(ScopeDefinition)
 		out := "allowed_domains:\n"

--- a/internal/swarm/agents/confirmation.go
+++ b/internal/swarm/agents/confirmation.go
@@ -22,11 +22,11 @@ import (
 // bug-bounty output credible.
 //
 // Flow:
-//   1. Trigger on CVE_MATCH / MISCONFIGURATION findings with a Reproduce block
-//   2. Re-run Reproduce.Command (shell-safe split) OR Reproduce.HTTPRequest
-//   3. If ExpectedIndicator appears in the output → leave the finding alone
-//   4. If it doesn't → write a superseding finding with pheromone 0.1
-//      (effectively hidden from downstream consumers + the final report)
+//  1. Trigger on CVE_MATCH / MISCONFIGURATION findings with a Reproduce block
+//  2. Re-run Reproduce.Command (shell-safe split) OR Reproduce.HTTPRequest
+//  3. If ExpectedIndicator appears in the output → leave the finding alone
+//  4. If it doesn't → write a superseding finding with pheromone 0.1
+//     (effectively hidden from downstream consumers + the final report)
 type ConfirmationAgent struct {
 	scopeDef   *scope.ScopeDefinition
 	campaignID uuid.UUID
@@ -108,7 +108,7 @@ func (a *ConfirmationAgent) Handle(ctx context.Context, f blackboard.Finding, bo
 
 // reproduce dispatches Command or HTTPRequest and checks for the indicator.
 // Returns (passed, output, fatalErr) — fatalErr is only for transport-level
-// problems (cancelled ctx, unreachable host). A non-matching indicator is
+// problems (canceled ctx, unreachable host). A non-matching indicator is
 // (false, output, nil) — a "did not repro" signal, not an error.
 func (a *ConfirmationAgent) reproduce(ctx context.Context, r *pipeline.Reproduction) (bool, string, error) {
 	if r.Command != "" {

--- a/internal/swarm/agents/confirmation_test.go
+++ b/internal/swarm/agents/confirmation_test.go
@@ -125,7 +125,7 @@ func TestConfirmation_HTTPReproduction(t *testing.T) {
 }
 
 // Stripping the scheme off an httptest URL gives us a hostname:port the
-// scope validator recognises.
+// scope validator recognizes.
 func stripScheme(u string) string {
 	for _, prefix := range []string{"https://", "http://"} {
 		if len(u) > len(prefix) && u[:len(prefix)] == prefix {

--- a/internal/swarm/agents/nuclei_author.go
+++ b/internal/swarm/agents/nuclei_author.go
@@ -27,12 +27,12 @@ import (
 //   - classifier marked high/critical severity (worth writing a template for)
 //   - don't already have a CVE id (novel — existing CVEs already have templates)
 type NucleiAuthorAgent struct {
-	provider    llm.Provider
-	campaignID  uuid.UUID
-	outputDir   string
-	parallel    int
-	validate    bool // run `nuclei -validate` on drafts before publishing
-	tun         *tuning.Settings
+	provider   llm.Provider
+	campaignID uuid.UUID
+	outputDir  string
+	parallel   int
+	validate   bool // run `nuclei -validate` on drafts before publishing
+	tun        *tuning.Settings
 }
 
 // NewNucleiAuthorAgent constructs the author. outputDir is where draft

--- a/internal/swarm/blackboard/memory.go
+++ b/internal/swarm/blackboard/memory.go
@@ -50,7 +50,7 @@ func NewMemoryBoard(now func() time.Time) *MemoryBoard {
 	}
 }
 
-// AgentBudget reads (or initialises) the budget for (campaign, agent).
+// AgentBudget reads (or initializes) the budget for (campaign, agent).
 func (b *MemoryBoard) AgentBudget(ctx context.Context, campaignID uuid.UUID, agent string) (AgentBudget, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/swarm/blackboard/postgres.go
+++ b/internal/swarm/blackboard/postgres.go
@@ -44,7 +44,7 @@ func (b *PostgresBoard) Write(ctx context.Context, f Finding, opts ...WriteOptio
 		pheromoneBase: 1.0,
 		halfLifeSec:   3600,
 	}
-	// Honour the Finding fields if already set (explicit wins).
+	// Honor the Finding fields if already set (explicit wins).
 	if f.PheromoneBase != 0 {
 		o.pheromoneBase = f.PheromoneBase
 	}

--- a/internal/swarm/blackboard/types.go
+++ b/internal/swarm/blackboard/types.go
@@ -3,7 +3,7 @@
 // The blackboard replaces the sequential 5-phase runner. Agents read and write
 // findings tagged with a type; their trigger predicates wake them when
 // relevant state appears. Pheromone weights decay over time so the swarm
-// naturally prioritises recent, high-signal findings and lets stale paths die.
+// naturally prioritizes recent, high-signal findings and lets stale paths die.
 package blackboard
 
 import (
@@ -41,7 +41,7 @@ const (
 	TypeCampaignComplete FindingType = "CAMPAIGN_COMPLETE"
 	TypeAgentError       FindingType = "AGENT_ERROR"
 
-	// Generated artefacts — nuclei templates, playbook drafts, etc.
+	// Generated artifacts — nuclei templates, playbook drafts, etc.
 	TypeNucleiTemplateDraft FindingType = "NUCLEI_TEMPLATE_DRAFT"
 )
 
@@ -84,7 +84,7 @@ type Predicate struct {
 	Limit int
 }
 
-// WriteOption customises a Write call.
+// WriteOption customizes a Write call.
 type WriteOption func(*writeOpts)
 
 type writeOpts struct {

--- a/internal/swarm/memorygraft/detector.go
+++ b/internal/swarm/memorygraft/detector.go
@@ -27,10 +27,10 @@ import (
 
 // Alert describes one suspicious pattern detected on the blackboard.
 type Alert struct {
-	Kind        string    // "burst" | "repeat-title" | "duplicate-data" | "type-mismatch"
-	AgentName   string    // the agent that authored the suspicious findings
-	Description string    // human-readable summary
-	Severity    string    // "low" | "medium" | "high"
+	Kind        string // "burst" | "repeat-title" | "duplicate-data" | "type-mismatch"
+	AgentName   string // the agent that authored the suspicious findings
+	Description string // human-readable summary
+	Severity    string // "low" | "medium" | "high"
 	FirstSeen   time.Time
 	Count       int // how many findings make up this signal
 }

--- a/internal/toolprobe/probe.go
+++ b/internal/toolprobe/probe.go
@@ -11,10 +11,10 @@ import (
 
 // Tool is one external binary that Pentest Swarm AI can use if present.
 type Tool struct {
-	Name         string // the PATH name we look up (e.g. "nmap")
-	Purpose      string // one-line description shown in the init report
-	InstallHint  string // OS-appropriate install command
-	Critical     bool   // if true, missing = degraded core capability
+	Name        string // the PATH name we look up (e.g. "nmap")
+	Purpose     string // one-line description shown in the init report
+	InstallHint string // OS-appropriate install command
+	Critical    bool   // if true, missing = degraded core capability
 }
 
 // Group is a themed bucket of tools.

--- a/internal/tools/coordinator_test.go
+++ b/internal/tools/coordinator_test.go
@@ -188,10 +188,10 @@ func TestRunAll_HooksFireForEveryAvailableTool(t *testing.T) {
 	c := newFakeCoordinator(a, b, skipped)
 
 	var (
-		mu       sync.Mutex
-		starts   = map[string]int{}
-		dones    = map[string]int{}
-		skips    = map[string]int{}
+		mu     sync.Mutex
+		starts = map[string]int{}
+		dones  = map[string]int{}
+		skips  = map[string]int{}
 	)
 	c.SetHooks(&ToolHooks{
 		OnStart: func(name, _ string) { mu.Lock(); starts[name]++; mu.Unlock() },

--- a/internal/tools/executor_test.go
+++ b/internal/tools/executor_test.go
@@ -23,7 +23,7 @@ func TestRunCommandWithStdin_PassesPayload(t *testing.T) {
 
 func TestRunCommandWithStdin_EmptyStdinIsLegacyBehavior(t *testing.T) {
 	// When stdin is empty the function must not block waiting for
-	// input — same behaviour as the old RunCommand. `printf hi` is
+	// input — same behavior as the old RunCommand. `printf hi` is
 	// stdin-free so any block would surface as a context timeout.
 	if !IsCommandAvailable("printf") {
 		t.Skip("printf not in PATH")
@@ -41,7 +41,7 @@ func TestRunCommandWithStdin_EmptyStdinIsLegacyBehavior(t *testing.T) {
 
 func TestRunCommandWithStdin_ContextCancelKillsChild(t *testing.T) {
 	// `cat` with empty stdin will block on EOF; CommandContext must
-	// terminate it when the context is cancelled.
+	// terminate it when the context is canceled.
 	if !IsCommandAvailable("cat") {
 		t.Skip("cat not in PATH")
 	}

--- a/internal/tools/httpx.go
+++ b/internal/tools/httpx.go
@@ -10,8 +10,8 @@ import (
 
 type HttpxTool struct{}
 
-func NewHttpxTool() *HttpxTool { return &HttpxTool{} }
-func (h *HttpxTool) Name() string { return "httpx" }
+func NewHttpxTool() *HttpxTool         { return &HttpxTool{} }
+func (h *HttpxTool) Name() string      { return "httpx" }
 func (h *HttpxTool) IsAvailable() bool { return IsCommandAvailable("httpx") }
 
 func (h *HttpxTool) Run(ctx context.Context, target string, opts Options) (*ToolResult, error) {

--- a/internal/tools/katana_test.go
+++ b/internal/tools/katana_test.go
@@ -93,7 +93,7 @@ func sleepBin(t *testing.T, name string, seconds int) {
 func assertErrored(t *testing.T, err error, res *ToolResult, runDur, maxDur time.Duration) {
 	t.Helper()
 	if runDur > maxDur {
-		t.Fatalf("Run() took %v, exceeds bound %v — wrapper did not honour timeout / cancellation", runDur, maxDur)
+		t.Fatalf("Run() took %v, exceeds bound %v — wrapper did not honor timeout / cancellation", runDur, maxDur)
 	}
 	if err != nil {
 		return // surfaced via returned error — good
@@ -152,7 +152,7 @@ func flagValue(argv []string, flag string) string {
 // --- katana tests ----------------------------------------------------
 
 func TestKatana_UsesJSONLFlag(t *testing.T) {
-	// Regression test for the v1.x behaviour where -json was removed.
+	// Regression test for the v1.x behavior where -json was removed.
 	// The wrapper must emit -jsonl, never -json, or katana exits with
 	// "flag provided but not defined: -json".
 	dir := fakeBin(t, "katana", `{"timestamp":"2026-01-01T00:00:00Z","request":{"endpoint":"https://example.com"}}`, 0)

--- a/internal/tools/nmap.go
+++ b/internal/tools/nmap.go
@@ -65,15 +65,15 @@ func (n *NmapTool) Run(ctx context.Context, target string, opts Options) (*ToolR
 	for _, h := range hosts {
 		for _, p := range h.Ports {
 			result.ParsedFindings = append(result.ParsedFindings, map[string]any{
-				"ip":         h.Address,
-				"hostnames":  h.Hostnames,
-				"port":       p.PortID,
-				"protocol":   p.Protocol,
-				"state":      p.State,
-				"service":    p.Service,
-				"version":    p.Version,
-				"product":    p.Product,
-				"os":         h.OS,
+				"ip":        h.Address,
+				"hostnames": h.Hostnames,
+				"port":      p.PortID,
+				"protocol":  p.Protocol,
+				"state":     p.State,
+				"service":   p.Service,
+				"version":   p.Version,
+				"product":   p.Product,
+				"os":        h.OS,
 			})
 		}
 	}
@@ -111,10 +111,10 @@ type nmapPorts struct {
 }
 
 type nmapPort struct {
-	Protocol string     `xml:"protocol,attr"`
-	PortID   int        `xml:"portid,attr"`
-	State    nmapState  `xml:"state"`
-	Service  nmapSvc    `xml:"service"`
+	Protocol string    `xml:"protocol,attr"`
+	PortID   int       `xml:"portid,attr"`
+	State    nmapState `xml:"state"`
+	Service  nmapSvc   `xml:"service"`
 }
 
 type nmapState struct {

--- a/internal/tools/sqlmap.go
+++ b/internal/tools/sqlmap.go
@@ -96,13 +96,13 @@ func (s *SqlmapTool) Run(ctx context.Context, target string, opts Options) (*Too
 
 	// 2. Configure options (URL + sensible-defaults for an authorized pentest).
 	optsPayload := map[string]any{
-		"url":      target,
-		"level":    opts.GetInt("level", 2),
-		"risk":     opts.GetInt("risk", 1),
-		"batch":    true,
+		"url":          target,
+		"level":        opts.GetInt("level", 2),
+		"risk":         opts.GetInt("risk", 1),
+		"batch":        true,
 		"flushSession": true,
-		"technique":     opts.GetString("technique", "BEUSTQ"),
-		"timeout":       opts.GetInt("req_timeout", 30),
+		"technique":    opts.GetString("technique", "BEUSTQ"),
+		"timeout":      opts.GetInt("req_timeout", 30),
 	}
 	if err := apiPost(runCtx, client, endpoint+"/option/"+taskID+"/set", optsPayload, nil); err != nil {
 		return result, fmt.Errorf("sqlmap option/set: %w", err)

--- a/internal/tools/sqlmap_test.go
+++ b/internal/tools/sqlmap_test.go
@@ -36,10 +36,10 @@ func buildFakeSqlmapServer(t *testing.T) *httptest.Server {
 			"success": true,
 			"data": []map[string]any{
 				{
-					"type":      "vulnerable",
-					"parameter": "id",
-					"place":     "GET",
-					"technique": "UNION query",
+					"type":        "vulnerable",
+					"parameter":   "id",
+					"place":       "GET",
+					"technique":   "UNION query",
 					"db_password": "s3cret!",
 					"raw_note":    "admin_password=hunter2",
 				},
@@ -95,7 +95,7 @@ func TestSqlmapTool_ScopeViolation(t *testing.T) {
 }
 
 func TestSqlmapTool_TimeoutCancels(t *testing.T) {
-	// Server that never terminates the scan — the adapter should honour timeout.
+	// Server that never terminates the scan — the adapter should honor timeout.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/task/new", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"success": true, "taskid": "slow-1"})
@@ -124,6 +124,6 @@ func TestSqlmapTool_TimeoutCancels(t *testing.T) {
 		t.Fatal("expected timeout error")
 	}
 	if time.Since(start) > 10*time.Second {
-		t.Fatal("adapter didn't honour timeout promptly")
+		t.Fatal("adapter didn't honor timeout promptly")
 	}
 }

--- a/tests/bench/cybench/runner.go
+++ b/tests/bench/cybench/runner.go
@@ -7,12 +7,12 @@
 // piece of work. Tracked as Phase 3.3.1.
 //
 // To wire up the actual challenges:
-//   1. Clone the Cybench repo (https://github.com/andyzorigin/cybench)
-//      into ./fixtures/ — kept out of git via .gitignore
-//   2. Implement LoadChallenges() to walk fixtures/<challenge>/{prompt.md, flag.txt}
-//   3. Each challenge sandbox is launched via Docker; the swarm runs
-//      against it with --swarm --safe-mode + a 30-min budget
-//   4. Score: did the campaign report contain the flag? exact match.
+//  1. Clone the Cybench repo (https://github.com/andyzorigin/cybench)
+//     into ./fixtures/ — kept out of git via .gitignore
+//  2. Implement LoadChallenges() to walk fixtures/<challenge>/{prompt.md, flag.txt}
+//  3. Each challenge sandbox is launched via Docker; the swarm runs
+//     against it with --swarm --safe-mode + a 30-min budget
+//  4. Score: did the campaign report contain the flag? exact match.
 package cybench
 
 import (
@@ -23,12 +23,12 @@ import (
 
 // Challenge is one Cybench task.
 type Challenge struct {
-	ID          string        // e.g. "web/easy/sqli-1"
-	Category    string        // web | crypto | pwn | forensics | misc
-	Difficulty  string        // easy | medium | hard
-	Prompt      string        // the challenge description shown to the swarm
-	ExpectedFlag string       // exact flag substring; campaign succeeds if this appears in any artifact
-	TimeBudget  time.Duration // per-challenge cap (default 30m)
+	ID           string        // e.g. "web/easy/sqli-1"
+	Category     string        // web | crypto | pwn | forensics | misc
+	Difficulty   string        // easy | medium | hard
+	Prompt       string        // the challenge description shown to the swarm
+	ExpectedFlag string        // exact flag substring; campaign succeeds if this appears in any artifact
+	TimeBudget   time.Duration // per-challenge cap (default 30m)
 }
 
 // Result is one challenge's outcome.

--- a/tests/integration/swarm_e2e_test.go
+++ b/tests/integration/swarm_e2e_test.go
@@ -16,11 +16,11 @@ import (
 // TestSwarmEndToEnd_StubbedAgents runs the full scheduler loop with
 // stubbed agents standing in for recon / classifier / exploit.
 // Verifies three invariants of the swarm model:
-//   1. Findings flow strictly via the blackboard — no direct agent→agent calls.
-//   2. An agent's Trigger predicate gates dispatch: classifier only fires on
-//      raw recon findings, exploit only on CVE_MATCH above the pheromone gate.
-//   3. The scheduler returns cleanly once CAMPAIGN_COMPLETE is written and
-//      the final board snapshot matches the golden list.
+//  1. Findings flow strictly via the blackboard — no direct agent→agent calls.
+//  2. An agent's Trigger predicate gates dispatch: classifier only fires on
+//     raw recon findings, exploit only on CVE_MATCH above the pheromone gate.
+//  3. The scheduler returns cleanly once CAMPAIGN_COMPLETE is written and
+//     the final board snapshot matches the golden list.
 //
 // No LLM, no Postgres, no network — everything is in-process so this test
 // runs in CI in <1 s.

--- a/tests/llm_eval/harness.go
+++ b/tests/llm_eval/harness.go
@@ -39,13 +39,13 @@ type Fixture struct {
 // look like. All set fields must hold (AND semantics). Unset fields are
 // ignored — so a fixture can check only severity without constraining CVSS.
 type Rubric struct {
-	Severity             string   `yaml:"severity,omitempty"`
-	SeverityAnyOf        []string `yaml:"severity_any_of,omitempty"`
-	CVSSMin              float64  `yaml:"cvss_min,omitempty"`
-	CVSSMax              float64  `yaml:"cvss_max,omitempty"`
-	ConfidenceAnyOf      []string `yaml:"confidence_any_of,omitempty"`
-	AttackCategoryAnyOf  []string `yaml:"attack_category_any_of,omitempty"`
-	ContainsInDescription string  `yaml:"contains_in_description,omitempty"`
+	Severity              string   `yaml:"severity,omitempty"`
+	SeverityAnyOf         []string `yaml:"severity_any_of,omitempty"`
+	CVSSMin               float64  `yaml:"cvss_min,omitempty"`
+	CVSSMax               float64  `yaml:"cvss_max,omitempty"`
+	ConfidenceAnyOf       []string `yaml:"confidence_any_of,omitempty"`
+	AttackCategoryAnyOf   []string `yaml:"attack_category_any_of,omitempty"`
+	ContainsInDescription string   `yaml:"contains_in_description,omitempty"`
 }
 
 // LoadFixtures reads every .yaml under dir recursively.


### PR DESCRIPTION
These are purely cosmetic changes that will not alter the compiled binary or application logic.

Linter rules: gofmt, goimports, misspell

What it fixes: Unformatted files, disorganized imports, and typos (like artefacts -> artifacts, behaviour -> behavior).

Description:
This PR addresses purely cosmetic linter warnings flagged by gofmt, goimports, and misspell.

Changes:

Standardized file formatting and import ordering across the codebase.

Fixed localized typos (e.g., standardizing American English spellings like "behavior" and "customizes").

Impact:
Zero logical changes. No breaking changes. This is strictly code hygiene to keep our CI green.