### PR TITLE
security(deps): bump Next.js to 15.5.16 to patch SSRF and React2Shell

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "^15.0.0",
+    "next": "^15.5.16",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "@tanstack/react-query": "^5.0.0",


### PR DESCRIPTION
This PR updates next to ^15.5.16 to address two critical security vulnerabilities affecting our frontend stack.

Vulnerabilities Addressed:

CVE-2026-44578 (High - CVSS 8.6): Patches a Server-Side Request Forgery (SSRF) in the Next.js WebSocket upgrade handler that allowed internal network scanning on self-hosted deployments.

CVE-2025-55182 "React2Shell" (Critical - CVSS 10.0): Mitigates an insecure deserialization flaw in React Server Components that allowed unauthenticated Remote Code Execution via exposed Server Functions.

Changes:

Bumped next in package.json to 15.5.16.

Regenerated the lockfile to update the dependency tree.

Impact:
No breaking changes to application logic. This is strictly a dependency bump for security compliance.