### PR TITLE
fix: bare-IP targets scan nothing; Ollama silently truncates context to 4096 tokens

### DIFF
--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -413,12 +414,25 @@ func buildScope(scopes []string) (*scope.ScopeDefinition, error) {
 		if s == "" {
 			continue
 		}
-		// If it contains a /, treat as CIDR
+		// If it contains a /, treat as CIDR.
 		if strings.Contains(s, "/") {
 			def.AllowedCIDRs = append(def.AllowedCIDRs, s)
-		} else {
-			def.AllowedDomains = append(def.AllowedDomains, s)
+			continue
 		}
+		// A bare IP (no mask) is a host, not a domain. Scope validation
+		// checks IP targets against AllowedCIDRs only, so a bare IP filed
+		// under AllowedDomains is judged out-of-scope and every tool skips
+		// the target — recon returns 0 findings. Normalise it to a
+		// single-host CIDR (/32 for IPv4, /128 for IPv6).
+		if ip := net.ParseIP(s); ip != nil {
+			if ip.To4() != nil {
+				def.AllowedCIDRs = append(def.AllowedCIDRs, s+"/32")
+			} else {
+				def.AllowedCIDRs = append(def.AllowedCIDRs, s+"/128")
+			}
+			continue
+		}
+		def.AllowedDomains = append(def.AllowedDomains, s)
 	}
 	if len(def.AllowedCIDRs) == 0 && len(def.AllowedDomains) == 0 {
 		return nil, fmt.Errorf("scope must contain at least one domain or CIDR")

--- a/internal/engine/scope_build_test.go
+++ b/internal/engine/scope_build_test.go
@@ -1,0 +1,75 @@
+package engine
+
+import "testing"
+
+// TestBuildScopeBareIP pins the fix for the bare-IP scope bug: a target
+// like "192.168.1.10" (no mask) must land in AllowedCIDRs as a /32, not
+// in AllowedDomains. When filed as a domain, IP scope validation (which
+// only consults AllowedCIDRs) rejects the target and every recon tool
+// skips it, yielding 0 findings.
+func TestBuildScopeBareIP(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        []string
+		wantCIDRs []string
+		wantDoms  []string
+	}{
+		{
+			name:      "bare IPv4 becomes /32 CIDR",
+			in:        []string{"192.168.1.10"},
+			wantCIDRs: []string{"192.168.1.10/32"},
+			wantDoms:  nil,
+		},
+		{
+			name:      "bare IPv6 becomes /128 CIDR",
+			in:        []string{"2001:db8::1"},
+			wantCIDRs: []string{"2001:db8::1/128"},
+			wantDoms:  nil,
+		},
+		{
+			name:      "explicit CIDR is preserved",
+			in:        []string{"10.0.0.0/24"},
+			wantCIDRs: []string{"10.0.0.0/24"},
+			wantDoms:  nil,
+		},
+		{
+			name:      "domain stays a domain",
+			in:        []string{"example.com"},
+			wantCIDRs: nil,
+			wantDoms:  []string{"example.com"},
+		},
+		{
+			name:      "mixed scope is split correctly",
+			in:        []string{"192.168.1.10", "example.com", "10.0.0.0/24"},
+			wantCIDRs: []string{"192.168.1.10/32", "10.0.0.0/24"},
+			wantDoms:  []string{"example.com"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			def, err := buildScope(tc.in)
+			if err != nil {
+				t.Fatalf("buildScope(%v) returned error: %v", tc.in, err)
+			}
+			if !equalStrings(def.AllowedCIDRs, tc.wantCIDRs) {
+				t.Errorf("AllowedCIDRs = %v, want %v", def.AllowedCIDRs, tc.wantCIDRs)
+			}
+			if !equalStrings(def.AllowedDomains, tc.wantDoms) {
+				t.Errorf("AllowedDomains = %v, want %v", def.AllowedDomains, tc.wantDoms)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -63,6 +63,11 @@ type ollamaChatMessage struct {
 type ollamaOptions struct {
 	Temperature float64 `json:"temperature,omitempty"`
 	NumPredict  int     `json:"num_predict,omitempty"`
+	// NumCtx sets the model's context window. Without it, Ollama silently
+	// defaults to 4096 tokens regardless of the configured context_window,
+	// which truncates large recon tool outputs and collapses analysis to
+	// an empty surface. Wire it from the provider's contextWindow.
+	NumCtx int `json:"num_ctx,omitempty"`
 }
 
 type ollamaTool struct {
@@ -285,6 +290,7 @@ func (o *OllamaProvider) buildRequest(req CompletionRequest, stream bool) ollama
 		Options: ollamaOptions{
 			Temperature: req.Temperature,
 			NumPredict:  req.MaxTokens,
+			NumCtx:      o.contextWindow,
 		},
 	}
 

--- a/internal/llm/ollama_numctx_test.go
+++ b/internal/llm/ollama_numctx_test.go
@@ -1,0 +1,46 @@
+package llm
+
+import "testing"
+
+// TestOllamaSetsNumCtx pins the fix for the silent context-truncation bug:
+// the Ollama provider must send options.num_ctx derived from the configured
+// context window. Without it, Ollama defaults to 4096 tokens regardless of
+// config, truncating large recon tool outputs so the model never sees the
+// open ports — recon then collapses to an empty AttackSurface.
+func TestOllamaSetsNumCtx(t *testing.T) {
+	p := NewOllamaProvider(OllamaProviderConfig{
+		Model:         "qwen2.5:7b",
+		Endpoint:      "http://localhost:11434",
+		ContextWindow: 8192,
+	})
+
+	got := p.buildRequest(CompletionRequest{
+		SystemPrompt: "sys",
+		Messages:     []Message{{Role: "user", Content: "hi"}},
+		MaxTokens:    4096,
+		Temperature:  0.1,
+	}, false)
+
+	if got.Options.NumCtx != 8192 {
+		t.Errorf("Options.NumCtx = %d, want 8192 (configured context window)", got.Options.NumCtx)
+	}
+}
+
+// TestOllamaDefaultContextWindow verifies the provider falls back to a
+// sane non-zero context window when none is configured, so num_ctx is
+// never sent as 0 (which omitempty would drop, reviving the 4096 default).
+func TestOllamaDefaultContextWindow(t *testing.T) {
+	p := NewOllamaProvider(OllamaProviderConfig{
+		Model:    "qwen2.5:7b",
+		Endpoint: "http://localhost:11434",
+		// ContextWindow intentionally unset (0)
+	})
+
+	got := p.buildRequest(CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	}, false)
+
+	if got.Options.NumCtx <= 0 {
+		t.Errorf("Options.NumCtx = %d, want a positive default", got.Options.NumCtx)
+	}
+}


### PR DESCRIPTION
## Summary

Two independent bugs each caused IP scans to return **zero findings**. Found while running the tool against a single host with the local Ollama provider; fixed and verified end-to-end (CLI **and** API/dashboard paths) against a live Windows/IIS target — recon went from 0 → correct findings.

## Bug 1 — Bare-IP targets are misclassified as domains (`internal/engine/runner.go`)

`buildScope()` filed any scope entry without a `/` under `AllowedDomains`. But IP targets are validated **only** against `AllowedCIDRs` (see `internal/scope/validator.go` → `validateIP`). So a bare IP like `192.168.1.10` landed in `AllowedDomains`, was judged **out of scope**, and every recon tool skipped the target — recon finished in ~4s with 0 findings.

**Fix:** detect bare IPs and normalise them to single-host CIDRs (`/32` for IPv4, `/128` for IPv6) so they validate correctly. Users no longer need to remember `--scope <ip>/32`.

## Bug 2 — Ollama context window is ignored (`internal/llm/ollama.go`)

The provider never set `options.num_ctx`, so Ollama defaulted to **4096 tokens** regardless of the configured `context_window`. Combined recon output (naabu + httpx + nuclei) overflowed the window, the model never saw the discovered ports, and recon analysis collapsed to an empty `AttackSurface`.

**Fix:** wire `num_ctx` from the provider's context window.

## Tests

Adds unit tests for both fixes:
- `internal/engine/scope_build_test.go` — bare IPv4/IPv6 → CIDR, explicit CIDR preserved, domain stays a domain, mixed scope split.
- `internal/llm/ollama_numctx_test.go` — `num_ctx` is set from the configured window and never 0.

```
go test ./internal/engine ./internal/llm ./internal/scope   # all pass
```