### PR TITLE
fix(report): sanitize report path to prevent silent failure

### DIFF
--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -360,7 +360,9 @@ func (r *Runner) Run(ctx context.Context, cc CampaignConfig, onEvent EventCallba
 	}
 	os.MkdirAll(outputDir, 0755)
 
-	reportPath := filepath.Join(outputDir, fmt.Sprintf("%s-%s", campaign.Name, campaignID.String()[:8]))
+	safeName := strings.NewReplacer("://", "_", ":", "_", "/", "_", " ", "_").Replace(campaign.Name)
+	reportPath := filepath.Join(outputDir, fmt.Sprintf("%s-%s", safeName, campaignID.String()[:8]))
+	
 
 	if cc.Format == "all" || cc.Format == "md" || cc.Format == "" {
 		md, _ := renderer.ToMarkdown(pentestReport)


### PR DESCRIPTION
Report files silently failed to write when the target contained an invalid character (e.g. a URL format like http://). filepath.Join treated the portion after the slash as a subdirectory, so os.WriteFile wrote to a nonexistent path and failed, but the error was ignored, so the campaign reported success while writing nothing.

Fixes #55 

## Summary

<!-- One paragraph. What did you do, and why? -->

I added a safeName variable which replaces all possibly dangerous/malforming characters from the campaign name to an underscore, such that the created reportPath using this safeName will not be malformed.

## Plan item

Bug fix, no roadmap tracking issue.

## Testing

<!-- How did you verify this works? At minimum:
       - Unit tests added (`go test ./internal/<pkg>/...` passes)
       - Local build clean (`go build ./...`)
     For tool-adapter / external-API changes, also describe any manual
     end-to-end check you ran. -->

- [ ] Unit tests added or updated
- [x] `go build ./...` clean
- [x] `go test ./internal/...` green
- [x] Manual verification (if applicable): I ran a new campaign using the exact same command described in Issue #55 and the report successfully gets written to the correct path output.

## Anything reviewers should look at carefully?

<!-- Subtle behaviour change? Security-sensitive code? Public API
     change? Call it out explicitly so it doesn't get missed in review. -->
This PR fixes the malformed path, but the os.WriteFile error returns still are not checked (in the if blocks directly below the changes in the PR). These have not been modified to keep the PR scoped on the path sanitisation.

Report names for URL/path targets now use underscores, and bare domain/IP targets remain unchanged.

## Checklist

- [x] Commit messages follow the convention seen in `git log` (`feat(area): …`, `fix(area): …`, `docs(area): …`, etc.)
- [x] UK English in comments (the project uses defence / colour / customise / sanitise / artefact — not US spellings)
- [x] No unrelated scope creep — single feature / fix per PR
- [x] Contribution is under AGPL-3.0 (same as the project's LICENSE)
