### PR TITLE
feat(llm): add OrcaRouter as a named provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ All agents inherit from a single provider config. Set one key, the entire swarm 
 | **Claude** (default) | `export PENTESTSWARM_ORCHESTRATOR_API_KEY=...` | Cloud | Best quality, zero setup, prompt caching |
 | **Ollama** | Install Ollama + pull models | 100% local | Full privacy, air-gapped |
 | **LM Studio** | Load model, enable server | 100% local | GUI model management |
+| **[OrcaRouter](https://www.orcarouter.ai)** | `export PENTESTSWARM_ORCHESTRATOR_API_KEY=sk-orca-...` | Cloud | One endpoint for Claude/GPT + other frontier models, gateway-level security |
 
 ---
 
@@ -234,7 +235,7 @@ All agents inherit from a single provider config. Set one key, the entire swarm 
 |-----------|-----------|-----|
 | Platform | **Go 1.24** | Single binary, goroutine concurrency, native security tools |
 | CLI | **Cobra + bubbletea** | Beautiful TUI with multi-panel agent view |
-| LLM | **Claude API / Ollama / LM Studio** | Best quality cloud + full privacy local |
+| LLM | **Claude API / OrcaRouter / Ollama / LM Studio** | Best quality cloud + full privacy local |
 | Security Tools | **subfinder · httpx · nuclei · naabu · katana · dnsx · gau · nmap** | ProjectDiscovery Go libs + nmap subprocess |
 | Blackboard | **Postgres 16 + pgvector** | Transactional writes, vector similarity, pheromone decay in SQL |
 | Cache | **Redis 7** | Rate limiting, session state |

--- a/cli/config.go
+++ b/cli/config.go
@@ -30,8 +30,9 @@ var configInitCmd = &cobra.Command{
 		fmt.Println("  1) Claude (Anthropic API — best quality, recommended)")
 		fmt.Println("  2) Ollama (local models — full privacy, needs GPU)")
 		fmt.Println("  3) LM Studio (local, OpenAI-compatible)")
+		fmt.Println("  4) OrcaRouter (one endpoint, many frontier models — Claude, GPT, etc.)")
 		fmt.Println()
-		provider := prompt(reader, "  Choose provider [1/2/3]", "1")
+		provider := prompt(reader, "  Choose provider [1/2/3/4]", "1")
 
 		var providerName, apiKey, endpoint, model string
 
@@ -51,6 +52,14 @@ var configInitCmd = &cobra.Command{
 			providerName = "lmstudio"
 			endpoint = prompt(reader, "  LM Studio endpoint", "http://localhost:1234")
 			model = prompt(reader, "  Model name", "")
+		case "4", "orcarouter":
+			providerName = "orcarouter"
+			model = prompt(reader, "  Model (use openai/gpt-5.5 unless you need a specific one)", "openai/gpt-5.5")
+			apiKey = prompt(reader, "  OrcaRouter API key (sk-orca-...)", "")
+			endpoint = prompt(reader, "  OrcaRouter endpoint", "https://api.orcarouter.ai/v1")
+			if apiKey == "" {
+				fmt.Println(colorYellow("  No API key provided. Set PENTESTSWARM_ORCHESTRATOR_API_KEY env var later."))
+			}
 		default:
 			providerName = "claude"
 			model = "claude-sonnet-4-6"

--- a/cli/scan.go
+++ b/cli/scan.go
@@ -304,7 +304,7 @@ func init() {
 	scanCmd.Flags().String("scope", "", "CIDR or domain scope, comma-separated (required)")
 	scanCmd.Flags().String("objective", "find all vulnerabilities", "what to find")
 	scanCmd.Flags().String("mode", "manual", "manual|bugbounty|asm|ctf")
-	scanCmd.Flags().String("provider", "", "claude|ollama|lmstudio (overrides config)")
+	scanCmd.Flags().String("provider", "", "claude|ollama|lmstudio|orcarouter (overrides config)")
 	scanCmd.Flags().Bool("dry-run", false, "show planned commands without executing")
 	scanCmd.Flags().String("output", "./reports", "output directory for report")
 	scanCmd.Flags().String("format", "md", "report format: md|html|json|sarif|all")

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,13 +37,14 @@ redis:
 
 # --- Orchestrator (main AI) ---
 orchestrator:
-  provider: "claude"       # claude, openai, gemini, ollama, lmstudio
+  provider: "claude"       # claude, openai, gemini, ollama, lmstudio, orcarouter
   model: "claude-sonnet-4-6" # Model to use for orchestration
-  api_key: ""              # REQUIRED for Claude/OpenAI/Gemini — set via
+  api_key: ""              # REQUIRED for Claude/OpenAI/Gemini/OrcaRouter — set via
                            #   PENTESTSWARM_ORCHESTRATOR_API_KEY
   endpoint: ""             # Required for ollama/lmstudio (e.g. http://localhost:11434).
                            # For openai: optional override (Together AI / DeepSeek / Groq).
                            # For gemini: leave empty unless proxying.
+                           # For orcarouter: optional override (defaults to https://api.orcarouter.ai/v1).
   context_window: 200000   # Max context window size in tokens
   max_tokens: 8192         # Max output tokens per completion
   temperature: 0.1         # Lower = more deterministic
@@ -54,6 +55,17 @@ orchestrator:
 #   model: "gemini-2.5-flash"   # or gemini-2.5-pro / gemini-2.5-flash-lite
 #   api_key: "AIzaSy..."        # or set PENTESTSWARM_ORCHESTRATOR_API_KEY
 #   context_window: 1000000
+
+# --- OrcaRouter example (get a key at https://www.orcarouter.ai) ---
+# One endpoint with gateway-level, zero-trust security for AI agents, fronting
+# many frontier models (Claude, GPT, ...). The swarm depends on native tool
+# calling, so pin a fixed tool-capable model rather than orcarouter/auto.
+# orchestrator:
+#   provider: "orcarouter"
+#   model: "openai/gpt-5.5"     # or e.g. "anthropic/claude-sonnet-4.6"
+#   api_key: "sk-orca-..."      # or set PENTESTSWARM_ORCHESTRATOR_API_KEY
+#   endpoint: "https://api.orcarouter.ai/v1"
+#   context_window: 200000
 
 # --- Specialist Agent Models ---
 # By default, ALL agents inherit the orchestrator's provider and API key.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,7 +69,7 @@ func (r RedisConfig) Addr() string {
 }
 
 type OrchestratorConfig struct {
-	Provider      string  `mapstructure:"provider"` // claude, openai, ollama, lmstudio
+	Provider      string  `mapstructure:"provider"` // claude, openai, gemini, ollama, lmstudio, orcarouter
 	Model         string  `mapstructure:"model"`
 	APIKey        string  `mapstructure:"api_key"`
 	Endpoint      string  `mapstructure:"endpoint"`
@@ -89,14 +89,14 @@ type OrchestratorConfig struct {
 // path. Typically points at Together AI / DeepSeek / Ollama — providers
 // less prone to refusing offensive-security prompts than Claude.
 type FallbackConfig struct {
-	Provider string `mapstructure:"provider"` // openai, ollama, lmstudio
+	Provider string `mapstructure:"provider"` // openai, ollama, lmstudio, orcarouter
 	Model    string `mapstructure:"model"`
 	APIKey   string `mapstructure:"api_key"`
 	Endpoint string `mapstructure:"endpoint"`
 }
 
 type AgentModelConfig struct {
-	Provider string `mapstructure:"provider"` // claude, openai, ollama, lmstudio — empty means inherit from orchestrator
+	Provider string `mapstructure:"provider"` // claude, openai, ollama, lmstudio, orcarouter — empty means inherit from orchestrator
 	Model    string `mapstructure:"model"`
 	APIKey   string `mapstructure:"api_key"` // empty means inherit from orchestrator
 	Endpoint string `mapstructure:"endpoint"`
@@ -304,9 +304,9 @@ func Validate(cfg *Config) error {
 
 	// Orchestrator validation
 	switch cfg.Orchestrator.Provider {
-	case "claude":
+	case "claude", "openai", "gemini", "orcarouter":
 		if cfg.Orchestrator.APIKey == "" {
-			errs = append(errs, "orchestrator.api_key is required when provider is 'claude'")
+			errs = append(errs, fmt.Sprintf("orchestrator.api_key is required when provider is '%s'", cfg.Orchestrator.Provider))
 		}
 	case "ollama", "lmstudio":
 		if cfg.Orchestrator.Endpoint == "" {
@@ -316,9 +316,9 @@ func Validate(cfg *Config) error {
 			errs = append(errs, fmt.Sprintf("orchestrator.endpoint is not a valid URL: %s", err))
 		}
 	case "":
-		errs = append(errs, "orchestrator.provider is required (claude, ollama, or lmstudio)")
+		errs = append(errs, "orchestrator.provider is required (claude, openai, gemini, ollama, lmstudio, orcarouter)")
 	default:
-		errs = append(errs, fmt.Sprintf("orchestrator.provider '%s' is not valid — use claude, ollama, or lmstudio", cfg.Orchestrator.Provider))
+		errs = append(errs, fmt.Sprintf("orchestrator.provider '%s' is not valid — use claude, openai, gemini, ollama, lmstudio, or orcarouter", cfg.Orchestrator.Provider))
 	}
 
 	// Model name validation

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -104,8 +104,32 @@ func newProviderFromParams(provider, apiKey, model, endpoint string, contextWind
 			ContextWindow: contextWindow,
 		}), nil
 
+	case "orcarouter":
+		// OrcaRouter — an OpenAI-API-compatible gateway that fronts many
+		// frontier models (Claude, GPT, …) on a single endpoint, with
+		// gateway-level zero-trust security for AI agents. Get a key at
+		// https://www.orcarouter.ai. We reuse the OpenAI wire protocol and
+		// pin a fixed tool-calling-capable model by default: the swarm's
+		// orchestrator relies on native function calling, and routing to an
+		// unpinned "auto" pool could land on a model without tool support.
+		if apiKey == "" {
+			return nil, fmt.Errorf("orcarouter provider requires api_key — get one at https://www.orcarouter.ai and set PENTESTSWARM_ORCHESTRATOR_API_KEY or orchestrator.api_key in config.yaml")
+		}
+		if endpoint == "" {
+			endpoint = "https://api.orcarouter.ai/v1"
+		}
+		if model == "" {
+			model = "openai/gpt-5.5"
+		}
+		return NewOpenAIProvider(OpenAIProviderConfig{
+			APIKey:        apiKey,
+			Endpoint:      endpoint,
+			Model:         model,
+			ContextWindow: contextWindow,
+		}), nil
+
 	default:
-		return nil, fmt.Errorf("unknown provider %q — use claude, openai, gemini, ollama, or lmstudio", provider)
+		return nil, fmt.Errorf("unknown provider %q — use claude, openai, gemini, ollama, orcarouter, or lmstudio", provider)
 	}
 }
 

--- a/internal/llm/factory_orcarouter_test.go
+++ b/internal/llm/factory_orcarouter_test.go
@@ -1,0 +1,100 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/config"
+)
+
+// TestOrcaRouterProvider_Defaults verifies the orcarouter factory branch
+// wires an OpenAI-wire provider to OrcaRouter's endpoint and pins a fixed
+// tool-calling-capable model when none is configured. The swarm's
+// orchestrator depends on native function calling, so the default must
+// never be an unpinned "auto" pool that could land on a model without
+// tool support.
+func TestOrcaRouterProvider_Defaults(t *testing.T) {
+	p, err := NewProvider(config.OrchestratorConfig{
+		Provider: "orcarouter",
+		APIKey:   "sk-orca-test",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider(orcarouter): %v", err)
+	}
+
+	oai, ok := p.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("orcarouter should build an *OpenAIProvider, got %T", p)
+	}
+	if oai.endpoint != "https://api.orcarouter.ai/v1" {
+		t.Errorf("endpoint = %q, want https://api.orcarouter.ai/v1", oai.endpoint)
+	}
+	if oai.model != "openai/gpt-5.5" {
+		t.Errorf("model = %q, want openai/gpt-5.5", oai.model)
+	}
+	if !oai.SupportsToolUse() {
+		t.Error("orcarouter should default to native tool use (swarm depends on it)")
+	}
+	if p.ContextWindow() <= 0 {
+		t.Errorf("context window = %d, want > 0", p.ContextWindow())
+	}
+}
+
+// TestOrcaRouterProvider_CustomConfig verifies explicit endpoint/model
+// values pass straight through to the provider.
+func TestOrcaRouterProvider_CustomConfig(t *testing.T) {
+	p, err := NewProvider(config.OrchestratorConfig{
+		Provider:      "orcarouter",
+		APIKey:        "sk-orca-test",
+		Endpoint:      "https://proxy.example.com/v1",
+		Model:         "anthropic/claude-sonnet-4.6",
+		ContextWindow: 100000,
+	})
+	if err != nil {
+		t.Fatalf("NewProvider(orcarouter): %v", err)
+	}
+
+	oai := p.(*OpenAIProvider)
+	if oai.endpoint != "https://proxy.example.com/v1" {
+		t.Errorf("endpoint = %q", oai.endpoint)
+	}
+	if oai.model != "anthropic/claude-sonnet-4.6" {
+		t.Errorf("model = %q", oai.model)
+	}
+	if oai.contextWindow != 100000 {
+		t.Errorf("context window = %d, want 100000", oai.contextWindow)
+	}
+}
+
+// TestOrcaRouterProvider_RequiresAPIKey verifies the factory fails fast
+// with a clear message when no key is configured, and points the user at
+// OrcaRouter.
+func TestOrcaRouterProvider_RequiresAPIKey(t *testing.T) {
+	_, err := NewProvider(config.OrchestratorConfig{
+		Provider: "orcarouter",
+	})
+	if err == nil {
+		t.Fatal("expected error when orcarouter has no api_key")
+	}
+	if !strings.Contains(err.Error(), "api_key") {
+		t.Errorf("error should mention api_key: %v", err)
+	}
+	if !strings.Contains(err.Error(), "orcarouter.ai") {
+		t.Errorf("error should point at orcarouter.ai: %v", err)
+	}
+}
+
+// TestUnknownProvider_ErrorListsOrcaRouter ensures the unknown-provider
+// message advertises orcarouter as a valid option.
+func TestUnknownProvider_ErrorListsOrcaRouter(t *testing.T) {
+	_, err := NewProvider(config.OrchestratorConfig{
+		Provider: "nonsense",
+		APIKey:   "x",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+	if !strings.Contains(err.Error(), "orcarouter") {
+		t.Errorf("error should list orcarouter as a valid provider: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class, named LLM provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This wires it the same way the existing `openai` provider is wired — reusing `OpenAIProvider` (OpenAI chat-completions wire protocol, SSE streaming, native tool-use, `GET /models` health check) — with OrcaRouter's endpoint and a fixed tool-calling-capable default model so the swarm keeps working out of the box:

- `internal/llm/factory.go` — new `orcarouter` provider case. Endpoint defaults to `https://api.orcarouter.ai/v1`; model defaults to `openai/gpt-5.5`.
- `internal/config/config.go` — `Validate()` now accepts `openai` / `gemini` / `orcarouter` (openai/gemini were rejected by the validator even though the factory already supports them); provider comments updated.
- `cli/config.go` — the setup wizard now offers OrcaRouter as option 4.
- `cli/scan.go` — `--provider` flag help text includes `orcarouter`.
- `config.example.yaml` + `README.md` — named-provider row and example block.

I pinned a fixed model (`openai/gpt-5.5`) as the default rather than OrcaRouter's `orcarouter/auto` router pool, because the swarm depends on native function calling — an unpinned pool could land on an upstream without tool support. Users can pick any other OrcaRouter-hosted model (e.g. `anthropic/claude-sonnet-4.6`) via config.

## Plan item

Extends the existing `1.4.6 OpenAI-compatible provider` plan item (`IMPLEMENTATION_PLAN.md`). No tracking issue open yet.

Closes #

## Testing

- [x] Unit tests added or updated — `internal/llm/factory_orcarouter_test.go`: defaults, custom-config passthrough, missing-key error, unknown-provider message
- [x] `go build ./...` clean
- [x] `go test ./internal/llm/...` green
- [x] Manual verification — live end-to-end against `https://api.orcarouter.ai/v1`: `GET /models` → 200; `POST /chat/completions` with a `tools` array → 200 with `tool_calls` for `openai/gpt-5.5` (streaming and non-streaming); invalid key → 401

## Anything reviewers should look at carefully?

The `orcarouter` default model is pinned to `openai/gpt-5.5`. The swarm's ReAct loop sends a `tools` array on every request; if the default were an unpinned `orcarouter/auto` pool that can select a non-tool-calling upstream, requests would 400 with "function calling is not enabled for this model". The wizard and example config document how to change the model.

## Checklist

- [x] Commit messages follow the convention seen in `git log` (`feat(area): …`, `fix(area): …`, `docs(area): …`, etc.)
- [x] UK English in comments (the project uses defence / colour / customise / sanitise / artefact — not US spellings)
- [x] No unrelated scope creep — single feature per PR
- [x] Contribution is under AGPL-3.0 (same as the project's LICENSE)
