### PR TITLE
fix: preserve discovered recon endpoints when LLM output drifts

### DIFF
--- a/internal/agent/recon/agent.go
+++ b/internal/agent/recon/agent.go
@@ -156,12 +156,13 @@ func (r *ReconAgent) Analyze(ctx context.Context, results []*tools.ToolResult, c
 			if r.onErr != nil {
 				r.onErr(fmt.Errorf("recon analysis returned empty surface: %w", err))
 			}
-			// Return partial results rather than error (degraded mode).
-			return &pipeline.AttackSurface{
-				CampaignID: campaignID,
-				CreatedAt:  time.Now(),
-			}, nil
+			// Return deterministic partial results rather than error (degraded mode).
+			surface = &pipeline.AttackSurface{}
 		}
+	}
+
+	if recovered := reconcileToolResults(surface, results); recovered && err == nil && r.onErr != nil {
+		r.onErr(fmt.Errorf("recon analysis omitted discoveries parsed from tool output; recovered deterministic findings"))
 	}
 
 	surface.CampaignID = campaignID

--- a/internal/agent/recon/agent_test.go
+++ b/internal/agent/recon/agent_test.go
@@ -1,0 +1,115 @@
+package recon
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/llm"
+	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/tools"
+	"github.com/google/uuid"
+)
+
+type scriptedProvider struct {
+	responses []string
+	errors    []error
+	calls     int
+}
+
+func (p *scriptedProvider) Complete(_ context.Context, _ llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	call := p.calls
+	p.calls++
+	if call < len(p.errors) && p.errors[call] != nil {
+		return nil, p.errors[call]
+	}
+	return &llm.CompletionResponse{Content: p.responses[call]}, nil
+}
+
+func (p *scriptedProvider) Stream(context.Context, llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *scriptedProvider) HealthCheck(context.Context) error { return nil }
+func (p *scriptedProvider) ModelName() string                 { return "scripted" }
+func (p *scriptedProvider) ContextWindow() int                { return 8192 }
+func (p *scriptedProvider) SupportsToolUse() bool             { return false }
+
+func TestAnalyze_ReconcilesToolFindingsWhenValidLLMOutputDrifts(t *testing.T) {
+	provider := &scriptedProvider{responses: []string{`{"host":"example.com","ports":[443]}`}}
+	var degradedErr error
+	agent := NewReconAgent(provider, nil, WithErrorSink(func(err error) { degradedErr = err }))
+	results := []*tools.ToolResult{
+		{
+			ToolName: "katana",
+			ParsedFindings: []map[string]any{
+				{"request": map[string]any{"endpoint": "https://example.com/a"}},
+				{"request": map[string]any{"endpoint": "https://example.com/b"}},
+			},
+		},
+		{
+			ToolName: "dnsx",
+			ParsedFindings: []map[string]any{
+				{"host": "192.0.2.10", "subdomain": "api.example.com"},
+			},
+		},
+	}
+	campaignID := uuid.New()
+
+	surface, err := agent.Analyze(context.Background(), results, campaignID)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(surface.Endpoints) != 2 || surface.Endpoints[0].URL != "https://example.com/a" || surface.Endpoints[1].URL != "https://example.com/b" {
+		t.Fatalf("Katana endpoints were not preserved: %+v", surface.Endpoints)
+	}
+	if len(surface.Hosts) != 1 || surface.Hosts[0].IP != "192.0.2.10" {
+		t.Fatalf("tool host was not preserved: %+v", surface.Hosts)
+	}
+	if len(surface.Subdomains) != 1 || surface.Subdomains[0].Domain != "api.example.com" {
+		t.Fatalf("tool subdomain was not preserved: %+v", surface.Subdomains)
+	}
+	if surface.CampaignID != campaignID || surface.CreatedAt.IsZero() {
+		t.Fatalf("surface metadata not stamped: %+v", surface)
+	}
+	if degradedErr == nil {
+		t.Fatal("expected degraded-mode error when tool findings recover LLM omissions")
+	}
+}
+
+func TestAnalyze_ParseFailureFallbackPreservesToolFindings(t *testing.T) {
+	results := []*tools.ToolResult{{
+		ToolName:       "katana",
+		ParsedFindings: []map[string]any{{"request": map[string]any{"endpoint": "https://example.com/recovered"}}},
+	}}
+
+	t.Run("non-strict", func(t *testing.T) {
+		provider := &scriptedProvider{responses: []string{"not json", "still not json"}}
+		var degradedErr error
+		agent := NewReconAgent(provider, nil, WithErrorSink(func(err error) { degradedErr = err }))
+
+		surface, err := agent.Analyze(context.Background(), results, uuid.New())
+		if err != nil {
+			t.Fatalf("Analyze: %v", err)
+		}
+		if len(surface.Endpoints) != 1 || surface.Endpoints[0].URL != "https://example.com/recovered" {
+			t.Fatalf("fallback surface lost deterministic endpoint: %+v", surface.Endpoints)
+		}
+		if degradedErr == nil || !strings.Contains(degradedErr.Error(), "recon analysis returned empty surface") {
+			t.Fatalf("degraded error = %v, want parse-fallback signal", degradedErr)
+		}
+	})
+
+	t.Run("strict", func(t *testing.T) {
+		provider := &scriptedProvider{responses: []string{"not json", "still not json"}}
+		agent := NewReconAgent(provider, nil, WithStrict())
+
+		surface, err := agent.Analyze(context.Background(), results, uuid.New())
+		if err == nil || !strings.Contains(err.Error(), "recon parse failed after retry") {
+			t.Fatalf("error = %v, want existing strict parse error", err)
+		}
+		if surface != nil {
+			t.Fatalf("strict mode returned fallback surface: %+v", surface)
+		}
+	})
+}

--- a/internal/agent/recon/parser.go
+++ b/internal/agent/recon/parser.go
@@ -3,6 +3,7 @@ package recon
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -187,19 +188,18 @@ func MergeToolResults(results []*tools.ToolResult) MergedData {
 	}
 
 	for _, r := range results {
-		if r.Error != nil {
+		if r == nil || r.Error != nil {
 			continue
 		}
 
 		for _, finding := range r.ParsedFindings {
-			if subdomain, ok := finding["subdomain"].(string); ok {
-				merged.Subdomains[subdomain] = true
-			}
-			if host, ok := finding["host"].(string); ok {
-				merged.Hosts[host] = true
-			}
-			if url, ok := finding["url"].(string); ok {
-				merged.Endpoints[url] = true
+			addStringFinding(merged.Subdomains, finding["subdomain"])
+			addStringFinding(merged.Hosts, finding["host"])
+			addStringFinding(merged.Endpoints, finding["url"])
+
+			request, ok := finding["request"].(map[string]any)
+			if ok {
+				addStringFinding(merged.Endpoints, request["endpoint"])
 			}
 		}
 	}
@@ -214,13 +214,97 @@ type MergedData struct {
 	Endpoints  map[string]bool
 }
 
+func addStringFinding(destination map[string]bool, value any) {
+	text, ok := value.(string)
+	if !ok {
+		return
+	}
+	text = strings.TrimSpace(text)
+	if text != "" {
+		destination[text] = true
+	}
+}
+
 // UniqueSubdomains returns the deduplicated subdomain list.
 func (m MergedData) UniqueSubdomains() []string {
-	result := make([]string, 0, len(m.Subdomains))
-	for s := range m.Subdomains {
-		result = append(result, s)
+	return sortedKeys(m.Subdomains)
+}
+
+// UniqueHosts returns the deduplicated host list.
+func (m MergedData) UniqueHosts() []string {
+	return sortedKeys(m.Hosts)
+}
+
+// UniqueEndpoints returns the deduplicated endpoint list.
+func (m MergedData) UniqueEndpoints() []string {
+	return sortedKeys(m.Endpoints)
+}
+
+func sortedKeys(values map[string]bool) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
 	}
+	sort.Strings(result)
 	return result
+}
+
+// reconcileToolResults supplements an LLM-produced surface with findings
+// deterministically parsed from successful recon tool output. Existing LLM
+// records win so their richer metadata is preserved.
+func reconcileToolResults(surface *pipeline.AttackSurface, results []*tools.ToolResult) bool {
+	merged := MergeToolResults(results)
+	recovered := false
+
+	subdomains := make(map[string]bool, len(surface.Subdomains))
+	for _, record := range surface.Subdomains {
+		if domain := strings.TrimSpace(record.Domain); domain != "" {
+			subdomains[domain] = true
+		}
+	}
+	for _, domain := range merged.UniqueSubdomains() {
+		if subdomains[domain] {
+			continue
+		}
+		surface.Subdomains = append(surface.Subdomains, pipeline.SubdomainRecord{
+			Domain: domain,
+			Source: "tool",
+		})
+		subdomains[domain] = true
+		recovered = true
+	}
+
+	hosts := make(map[string]bool, len(surface.Hosts))
+	for _, record := range surface.Hosts {
+		if host := strings.TrimSpace(record.IP); host != "" {
+			hosts[host] = true
+		}
+	}
+	for _, host := range merged.UniqueHosts() {
+		if hosts[host] {
+			continue
+		}
+		surface.Hosts = append(surface.Hosts, pipeline.HostRecord{IP: host})
+		hosts[host] = true
+		recovered = true
+	}
+
+	endpoints := make(map[string]bool, len(surface.Endpoints))
+	for _, record := range surface.Endpoints {
+		if endpoint := strings.TrimSpace(record.URL); endpoint != "" {
+			endpoints[endpoint] = true
+		}
+	}
+	for _, endpoint := range merged.UniqueEndpoints() {
+		if endpoints[endpoint] {
+			continue
+		}
+		surface.Endpoints = append(surface.Endpoints, pipeline.EndpointRecord{URL: endpoint})
+		endpoints[endpoint] = true
+		recovered = true
+	}
+
+	return recovered
 }
 
 // stripCodeFence removes markdown ```json ... ``` wrappers.

--- a/internal/agent/recon/parser_test.go
+++ b/internal/agent/recon/parser_test.go
@@ -1,7 +1,11 @@
 package recon
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/pipeline"
+	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/tools"
 )
 
 // TestParseAttackSurface_StrictShape is the happy path: a frontier-API
@@ -138,5 +142,93 @@ func TestParseAttackSurface_MissingFieldsAreNil(t *testing.T) {
 	}
 	if s.Subdomains != nil || s.Hosts != nil || s.Endpoints != nil || s.Technologies != nil {
 		t.Fatalf("missing fields should be nil; got s=%+v", s)
+	}
+}
+
+func TestMergeToolResults_NormalizesAndDeduplicatesFindings(t *testing.T) {
+	results := []*tools.ToolResult{
+		nil,
+		{
+			ToolName: "katana",
+			ParsedFindings: []map[string]any{
+				{"request": map[string]any{"endpoint": "https://example.com/a"}},
+				{"request": map[string]any{"endpoint": "https://example.com/a"}},
+				{"request": map[string]any{"endpoint": "  "}},
+				{"request": map[string]any{"endpoint": 42}},
+				{"request": "malformed"},
+			},
+		},
+		{
+			ToolName: "mixed",
+			ParsedFindings: []map[string]any{
+				{"url": " https://example.com/b ", "host": "192.0.2.10", "subdomain": "api.example.com"},
+				{"url": "", "host": " ", "subdomain": ""},
+			},
+		},
+		{
+			ToolName:       "failed",
+			Error:          errors.New("tool failed"),
+			ParsedFindings: []map[string]any{{"url": "https://ignored.example.com"}},
+		},
+	}
+
+	merged := MergeToolResults(results)
+	if len(merged.Endpoints) != 2 || !merged.Endpoints["https://example.com/a"] || !merged.Endpoints["https://example.com/b"] {
+		t.Fatalf("endpoints = %+v, want two normalized unique URLs", merged.Endpoints)
+	}
+	if len(merged.Hosts) != 1 || !merged.Hosts["192.0.2.10"] {
+		t.Fatalf("hosts = %+v, want one non-empty host", merged.Hosts)
+	}
+	if len(merged.Subdomains) != 1 || !merged.Subdomains["api.example.com"] {
+		t.Fatalf("subdomains = %+v, want one non-empty subdomain", merged.Subdomains)
+	}
+}
+
+func TestReconcileToolResults_SupplementsWithoutOverwritingLLMMetadata(t *testing.T) {
+	surface := &pipeline.AttackSurface{
+		Subdomains: []pipeline.SubdomainRecord{{Domain: "api.example.com", IP: "192.0.2.10", Source: "llm"}},
+		Hosts: []pipeline.HostRecord{{
+			IP:        "192.0.2.10",
+			Hostnames: []string{"api.example.com"},
+			OpenPorts: []int{443},
+			OS:        "Linux",
+		}},
+		Endpoints: []pipeline.EndpointRecord{{
+			URL:         "https://api.example.com/admin",
+			Method:      "POST",
+			StatusCode:  403,
+			Interesting: true,
+			Notes:       "authentication required",
+		}},
+	}
+	results := []*tools.ToolResult{{
+		ToolName: "recon",
+		ParsedFindings: []map[string]any{
+			{"subdomain": "api.example.com", "host": "192.0.2.10", "url": "https://api.example.com/admin"},
+			{"subdomain": "cdn.example.com", "host": "192.0.2.11", "url": "https://cdn.example.com/app.js"},
+		},
+	}}
+
+	recovered := reconcileToolResults(surface, results)
+	if !recovered {
+		t.Fatal("expected deterministic findings to supplement the surface")
+	}
+	if len(surface.Subdomains) != 2 || len(surface.Hosts) != 2 || len(surface.Endpoints) != 2 {
+		t.Fatalf("reconciled surface contains duplicates or omissions: %+v", surface)
+	}
+	if got := surface.Subdomains[0]; got.IP != "192.0.2.10" || got.Source != "llm" {
+		t.Fatalf("matching subdomain metadata was overwritten: %+v", got)
+	}
+	if got := surface.Hosts[0]; got.OS != "Linux" || len(got.OpenPorts) != 1 || got.OpenPorts[0] != 443 {
+		t.Fatalf("matching host metadata was overwritten: %+v", got)
+	}
+	if got := surface.Endpoints[0]; got.Method != "POST" || got.StatusCode != 403 || !got.Interesting || got.Notes == "" {
+		t.Fatalf("matching endpoint metadata was overwritten: %+v", got)
+	}
+	if reconcileToolResults(surface, results) {
+		t.Fatal("reconciling the same findings twice should not report another recovery")
+	}
+	if len(surface.Subdomains) != 2 || len(surface.Hosts) != 2 || len(surface.Endpoints) != 2 {
+		t.Fatalf("second reconciliation introduced duplicates: %+v", surface)
 	}
 }


### PR DESCRIPTION
## Summary

Extend the existing recon merge logic to normalize direct URL/host/subdomain fields and Katana's nested `request.endpoint`, ignoring failed or malformed tool results and deduplicating records by their stable identity. Reconcile those deterministic discoveries into the LLM-produced `AttackSurface` after both a normal parse and the non-strict degraded fallback, preserving richer LLM metadata when the same record already exists. Keep the existing retry and strict-mode contracts intact: LLM transport or syntactic parse failures still follow their current error behavior, while a semantically drifted but valid response can no longer erase evidence already parsed from tool JSONL.

The sequential scan runs Katana and other recon tools successfully, but a schema-drifted LLM response can leave the returned `AttackSurface` empty, causing the runner to report zero endpoints and continue to a zero-finding report. `ParseAttackSurface` deliberately tolerates missing or unparseable fields, so valid JSON using unexpected top-level names can appear successful while discarding the tool evidence. The repository already collects structured `ParsedFindings` and has a `MergeToolResults` helper, but `ReconAgent.Analyze` never reconciles those deterministic findings into the LLM-produced surface, and Katana's nested `request.endpoint` shape is not currently recognized. This plan addresses that sequential data-loss path only; it does not close the separate experimental swarm termination defect described in the same issue.

Closes #54

## Plan item

Closes #54

## Testing

- [x] Unit tests added or updated
- [x] `go build ./...` clean
- [x] `go test ./internal/...` green
- [ ] Manual verification (if applicable):
  Not verified: this needs a person on the named hardware or environment.
- A Katana result containing nested `request.endpoint` values plus an LLM response with an unexpected `host`/`ports` shape returns every discovered endpoint in the final attack surface. - Tool-derived endpoints, hosts, and subdomains supplement a partially populated LLM surface without duplicating matching records or overwriting richer LLM metadata. - The non-strict fallback returns available deterministic discoveries and emits a degraded-mode error when both LLM parse attempts fail; strict mode continues to return the existing parse error instead of silently recovering.

## Anything reviewers should look at carefully?

Nothing beyond what is described above.

## Checklist

- [x] Commit messages follow the convention seen in `git log` (`feat(area): …`, `fix(area): …`, `docs(area): …`, etc.)
- [ ] UK English in comments (the project uses defence / colour / customise / sanitise / artefact — not US spellings)
- [ ] No unrelated scope creep — single feature / fix per PR
- [ ] Contribution is under AGPL-3.0 (same as the project's LICENSE)
