### PR TITLE
fix(exploit): restore corrupted exploit.go and enforce tool allowlist in plans

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,9 +1,7 @@
-version: "3.9"
-
 services:
   pentestswarm:
     build:
-      context: ../..
+      context: ..
       dockerfile: deploy/docker/Dockerfile
     ports:
       - "8080:8080"
@@ -13,6 +11,8 @@ services:
       PENTESTSWARM_REDIS_HOST: redis
       PENTESTSWARM_ORCHESTRATOR_PROVIDER: ollama
       PENTESTSWARM_ORCHESTRATOR_ENDPOINT: http://ollama:11434
+    volumes:
+      - ../config.yaml:/home/swarm/config.yaml:ro
     depends_on:
       postgres:
         condition: service_healthy
@@ -49,7 +49,7 @@ services:
   ollama:
     image: ollama/ollama:latest
     ports:
-      - "11434:11434"
+      - "11435:11434"
     volumes:
       - ollama_models:/root/.ollama
     deploy:

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,6 +1,21 @@
 # syntax=docker/dockerfile:1.7
 #
-# Build stage — statically-linked Go binary, no cgo.
+# Dockerfile etendu — base officielle Armur-Ai/Pentest-Swarm-AI
+# + outils de securite compiles (le Dockerfile upstream ne livre que le
+#   binaire pentestswarm seul, 0/16 outils presents au demarrage)
+#
+# [Verifie 31/08/2026] nmap est disponible via apk (Alpine main/community).
+# nuclei/subfinder/httpx/naabu/katana/dnsx/gau/gowitness sont des binaires Go
+# non empaquetes pour Alpine : compiles ici via "go install" dans le stage
+# builder, puis copies dans l'image finale.
+#
+# [Non verifie] versions exactes des modules Go (@latest) : a figer avec un
+# tag de version explicite avant mise en production pour la reproductibilite
+# des builds (@latest peut changer entre deux "docker compose build").
+
+# ---------------------------------------------------------------------
+# Stage 1 — build du binaire pentestswarm (inchange par rapport a l'upstream)
+# ---------------------------------------------------------------------
 FROM golang:1.24-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates
@@ -22,21 +37,63 @@ RUN --mount=type=cache,target=/go/pkg/mod \
       -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
       -o /out/pentestswarm ./cmd/pentestswarm/
 
-# Runtime stage — non-root, minimal, read-only-friendly.
+# ---------------------------------------------------------------------
+# Stage 2 — compilation des outils de securite Go (recon + vuln scan)
+# Stage separe : evite de re-telecharger ces modules a chaque modification
+# du code de pentestswarm (cache Docker distinct du stage builder).
+# ---------------------------------------------------------------------
+FROM golang:1.24-alpine AS tools
+
+RUN apk add --no-cache git
+
+# GOTOOLCHAIN=auto : certains modules (nuclei v3.11.1 exige Go >= 1.26)
+# demandent une toolchain plus recente que celle de l'image de base.
+# "auto" autorise "go install" a telecharger la toolchain requise a la volee
+# au lieu d'echouer sous GOTOOLCHAIN=local (comportement par defaut).
+ENV GOTOOLCHAIN=auto
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest && \
+    CGO_ENABLED=0 go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest && \
+    CGO_ENABLED=0 go install github.com/projectdiscovery/httpx/cmd/httpx@latest && \
+    CGO_ENABLED=0 go install github.com/projectdiscovery/naabu/v2/cmd/naabu@latest && \
+    CGO_ENABLED=0 go install github.com/projectdiscovery/katana/cmd/katana@latest && \
+    CGO_ENABLED=0 go install github.com/projectdiscovery/dnsx/cmd/dnsx@latest && \
+    CGO_ENABLED=0 go install github.com/lc/gau/v2/cmd/gau@latest
+
+# ---------------------------------------------------------------------
+# Stage 3 — runtime, non-root, minimal (base identique a l'upstream)
+# ---------------------------------------------------------------------
 FROM alpine:3.20
 
-RUN apk add --no-cache ca-certificates tzdata curl \
+# nmap : seul outil de la liste doctor disponible directement via apk.
+# libpcap requis par naabu pour le scan SYN (sinon repli sur connect scan).
+RUN apk add --no-cache ca-certificates tzdata curl nmap libpcap \
     && addgroup -S swarm && adduser -S -G swarm -h /home/swarm swarm
 
 COPY --from=builder /out/pentestswarm /usr/local/bin/pentestswarm
+COPY --from=tools /go/bin/nuclei     /usr/local/bin/nuclei
+COPY --from=tools /go/bin/subfinder  /usr/local/bin/subfinder
+COPY --from=tools /go/bin/httpx      /usr/local/bin/httpx
+COPY --from=tools /go/bin/naabu      /usr/local/bin/naabu
+COPY --from=tools /go/bin/katana     /usr/local/bin/katana
+COPY --from=tools /go/bin/dnsx       /usr/local/bin/dnsx
+COPY --from=tools /go/bin/gau        /usr/local/bin/gau
 COPY --chown=swarm:swarm playbooks/ /usr/local/share/pentestswarm/playbooks/
 
 USER swarm
 WORKDIR /home/swarm
 
+# Templates nuclei — telechargement au premier lancement (reseau requis ce
+# jour-la uniquement). Pour un usage air-gapped, pre-telecharger les
+# templates sur une machine avec acces internet et les copier dans l'image
+# via un volume ou un COPY supplementaire avant build.
+RUN nuclei -update-templates -silent || true
+
 EXPOSE 8080
 
-LABEL org.opencontainers.image.title="Pentest Swarm AI" \
+LABEL org.opencontainers.image.title="Pentest Swarm AI (etendu)" \
       org.opencontainers.image.source="https://github.com/Armur-Ai/Pentest-Swarm-AI" \
       org.opencontainers.image.licenses="Apache-2.0"
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -5,9 +5,18 @@
 #   binaire pentestswarm seul, 0/16 outils presents au demarrage)
 #
 # [Verifie 31/08/2026] nmap est disponible via apk (Alpine main/community).
-# nuclei/subfinder/httpx/naabu/katana/dnsx/gau/gowitness sont des binaires Go
-# non empaquetes pour Alpine : compiles ici via "go install" dans le stage
-# builder, puis copies dans l'image finale.
+# nuclei/subfinder/httpx/naabu/katana/dnsx/gau/gobuster/gitleaks/ffuf sont
+# des binaires Go non empaquetes pour Alpine : compiles ici via "go install"
+# dans le stage builder, puis copies dans l'image finale.
+#
+# [Connu, non couvert] sqlmap/semgrep (Python), nikto (Perl), jwt_tool
+# (Python), ysoserial (Java), trufflehog (go.mod avec "replace" qui bloque
+# "go install") et gowitness (necessite un navigateur headless) restent
+# absents : ils demanderaient d'ajouter des toolchains entieres a l'image ou
+# de builder depuis les sources, hors scope de cette extension. Le
+# planificateur LLM peut toujours les proposer (ils sont enregistres dans le
+# coordinator) mais l'executor les rejettera faute de binaire — a traiter
+# separement si besoin.
 #
 # [Non verifie] versions exactes des modules Go (@latest) : a figer avec un
 # tag de version explicite avant mise en production pour la reproductibilite
@@ -60,7 +69,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go install github.com/projectdiscovery/naabu/v2/cmd/naabu@latest && \
     CGO_ENABLED=0 go install github.com/projectdiscovery/katana/cmd/katana@latest && \
     CGO_ENABLED=0 go install github.com/projectdiscovery/dnsx/cmd/dnsx@latest && \
-    CGO_ENABLED=0 go install github.com/lc/gau/v2/cmd/gau@latest
+    CGO_ENABLED=0 go install github.com/lc/gau/v2/cmd/gau@latest && \
+    CGO_ENABLED=0 go install github.com/OJ/gobuster/v3@latest && \
+    CGO_ENABLED=0 go install github.com/zricethezav/gitleaks/v8@latest && \
+    CGO_ENABLED=0 go install github.com/ffuf/ffuf/v2@latest
+# trufflehog omis : son go.mod contient des directives "replace" qui rendent
+# "go install .../trufflehog/v3@latest" impossible (erreur go tooling connue
+# en amont) — necessiterait de cloner le depot et builder depuis les sources,
+# hors scope de ce simple ajout de binaires.
+#
+# gowitness omis : fonctionnel uniquement avec un navigateur headless
+# (chromium) installe a cote, ce qui alourdirait significativement l'image
+# pour un outil de capture d'ecran seulement utile en phase de reporting.
 
 # ---------------------------------------------------------------------
 # Stage 3 — runtime, non-root, minimal (base identique a l'upstream)
@@ -80,6 +100,9 @@ COPY --from=tools /go/bin/naabu      /usr/local/bin/naabu
 COPY --from=tools /go/bin/katana     /usr/local/bin/katana
 COPY --from=tools /go/bin/dnsx       /usr/local/bin/dnsx
 COPY --from=tools /go/bin/gau        /usr/local/bin/gau
+COPY --from=tools /go/bin/gobuster   /usr/local/bin/gobuster
+COPY --from=tools /go/bin/gitleaks   /usr/local/bin/gitleaks
+COPY --from=tools /go/bin/ffuf       /usr/local/bin/ffuf
 COPY --chown=swarm:swarm playbooks/ /usr/local/share/pentestswarm/playbooks/
 
 USER swarm

--- a/internal/agent/exploit/agent.go
+++ b/internal/agent/exploit/agent.go
@@ -39,6 +39,7 @@ func (e *ExploitAgent) BuildPlan(ctx context.Context, findings pipeline.Classifi
 	findingsJSON, _ := json.Marshal(findings.Findings)
 	chainsJSON, _ := json.Marshal(ruleChains)
 	toolsJSON, _ := json.Marshal(allowedTools)
+	hints := toolUsageHints(allowedTools)
 
 	req := llm.CompletionRequest{
 		SystemPrompt: exploitSystemPrompt,
@@ -46,8 +47,8 @@ func (e *ExploitAgent) BuildPlan(ctx context.Context, findings pipeline.Classifi
 			{
 				Role: "user",
 				Content: fmt.Sprintf(
-					"Objective: %s\n\nAllowed tools (the ONLY executables the \"command\" field of each step may invoke — any other binary, including curl, wget, or shell one-liners, will be rejected before execution):\n%s\n\nClassified Findings:\n%s\n\nRule-Based Attack Chains:\n%s\n\nAnalyze these findings. Think through each one in <think> tags, then produce your attack plan as JSON.",
-					objective, string(toolsJSON), string(findingsJSON), string(chainsJSON),
+					"Objective: %s\n\nAllowed tools (the ONLY executables the \"command\" field of each step may invoke — any other binary, including curl, wget, or shell one-liners, will be rejected before execution):\n%s\n\nCLI syntax notes for tools prone to misuse (follow these exactly; other allowed tools use their standard flags):\n%s\n\nClassified Findings:\n%s\n\nRule-Based Attack Chains:\n%s\n\nAnalyze these findings. Think through each one in <think> tags, then produce your attack plan as JSON.",
+					objective, string(toolsJSON), hints, string(findingsJSON), string(chainsJSON),
 				),
 			},
 		},
@@ -89,6 +90,31 @@ func (e *ExploitAgent) BuildPlan(ctx context.Context, findings pipeline.Classifi
 	}
 
 	return plan, nil
+}
+
+// knownToolUsageHints documents correct CLI invocation for tools whose real
+// syntax commonly gets confused with unrelated conventions by the LLM (e.g.
+// gau takes its target positionally, not via a getopt-style -u flag like
+// httpx/nuclei do) — without this, generated steps fail at execution time
+// even though the tool itself is allowed and installed.
+var knownToolUsageHints = map[string]string{
+	"gau":  "gau <domain-or-URL> [--json] — target is a positional argument, NOT \"-u <target>\".",
+	"dnsx": "echo <host> | dnsx -json -silent -a -aaaa -cname -resp — resolve a known host via stdin. Do NOT use \"-d <domain>\" (that's subdomain brute-force mode and requires \"-w <wordlist>\", which isn't available here).",
+}
+
+// toolUsageHints returns the usage note for each allowed tool that has one,
+// joined as a bullet list (or a placeholder if none apply).
+func toolUsageHints(allowedTools []string) string {
+	var lines []string
+	for _, t := range allowedTools {
+		if hint, ok := knownToolUsageHints[t]; ok {
+			lines = append(lines, "- "+hint)
+		}
+	}
+	if len(lines) == 0 {
+		return "(none)"
+	}
+	return strings.Join(lines, "\n")
 }
 
 // AdaptPlan adjusts the attack plan based on execution results.

--- a/internal/agent/exploit/agent.go
+++ b/internal/agent/exploit/agent.go
@@ -27,13 +27,18 @@ func NewExploitAgent(provider llm.Provider) *ExploitAgent {
 }
 
 // BuildPlan constructs an attack plan from classified findings.
-func (e *ExploitAgent) BuildPlan(ctx context.Context, findings pipeline.ClassifiedFindingSet, objective string) (*pipeline.AttackPlan, error) {
+// allowedTools lists the executable names the executor will actually permit
+// (see Coordinator.RegisteredToolNames) — without this, the LLM has no way
+// to know that ad-hoc binaries like curl aren't usable, and every step
+// built around them is guaranteed to fail at execution time (#43 allowlist).
+func (e *ExploitAgent) BuildPlan(ctx context.Context, findings pipeline.ClassifiedFindingSet, objective string, allowedTools []string) (*pipeline.AttackPlan, error) {
 	// Step 1: Build rule-based chains
 	ruleChains := e.pathBuilder.BuildChains(findings.Findings)
 
 	// Step 2: Send to LLM for reasoning and enhancement
 	findingsJSON, _ := json.Marshal(findings.Findings)
 	chainsJSON, _ := json.Marshal(ruleChains)
+	toolsJSON, _ := json.Marshal(allowedTools)
 
 	req := llm.CompletionRequest{
 		SystemPrompt: exploitSystemPrompt,
@@ -41,8 +46,8 @@ func (e *ExploitAgent) BuildPlan(ctx context.Context, findings pipeline.Classifi
 			{
 				Role: "user",
 				Content: fmt.Sprintf(
-					"Objective: %s\n\nClassified Findings:\n%s\n\nRule-Based Attack Chains:\n%s\n\nAnalyze these findings. Think through each one in <think> tags, then produce your attack plan as JSON.",
-					objective, string(findingsJSON), string(chainsJSON),
+					"Objective: %s\n\nAllowed tools (the ONLY executables the \"command\" field of each step may invoke — any other binary, including curl, wget, or shell one-liners, will be rejected before execution):\n%s\n\nClassified Findings:\n%s\n\nRule-Based Attack Chains:\n%s\n\nAnalyze these findings. Think through each one in <think> tags, then produce your attack plan as JSON.",
+					objective, string(toolsJSON), string(findingsJSON), string(chainsJSON),
 				),
 			},
 		},
@@ -174,10 +179,14 @@ func mergePaths(ruleBased, llmGenerated []pipeline.AttackPath) []pipeline.Attack
 
 const exploitSystemPrompt = `You are a specialized penetration testing strategist. Your role is to construct multi-step attack chains from classified security findings.
 
+CRITICAL CONSTRAINT: every step's "command" field must invoke one of the tools listed as "Allowed tools" in the user message, using that tool's real CLI syntax. Do not use curl, wget, generic shell commands, or any executable not on that list — such steps are rejected by the executor before they run and waste the entire attack path. If the allowed tools can't achieve a step you'd otherwise want (e.g. a raw HTTP probe), express it using the closest allowed tool instead (e.g. httpx) rather than falling back to curl.
+
+This constraint applies EQUALLY to "cleanup_command": it is validated by the exact same allowlist as "command", so it must also either invoke one of the "Allowed tools" or be left as an empty string. Do not default to "rm", "curl", or any other unlisted binary for cleanup — most reconnaissance/scanning steps have nothing to clean up, so leave cleanup_command empty ("") unless the step itself creates a file or artifact that a listed tool can remove.
+
 For each finding, think through:
-1. How exploitable is this? What tools/techniques are needed?
+1. How exploitable is this? Which of the allowed tools/techniques are needed?
 2. Can this be chained with other findings for greater impact?
-3. What is the most efficient path to the stated objective?
+3. What is the most efficient path to the stated objective, given only the allowed tools?
 
 Output your thinking in <think> tags, then produce a JSON array of attack paths.
 

--- a/internal/agent/exploit/executor.go
+++ b/internal/agent/exploit/executor.go
@@ -63,6 +63,18 @@ func (e *Executor) WithSafeMode(on bool) *Executor {
 	return e
 }
 
+// AllowedToolNames returns the executable names this executor will accept,
+// so callers building an attack plan (which happens before Execute is ever
+// called) can tell the LLM what's actually usable. Empty slice means no
+// allowlist gate is configured.
+func (e *Executor) AllowedToolNames() []string {
+	names := make([]string, 0, len(e.allowedExecutables))
+	for n := range e.allowedExecutables {
+		names = append(names, n)
+	}
+	return names
+}
+
 // WithAllowedExecutables restricts the binaries the executor will
 // launch to the given set. The engine derives this list from
 // tools.Coordinator.RegisteredToolNames(), so adding a new tool

--- a/internal/agent/report/agent.go
+++ b/internal/agent/report/agent.go
@@ -3,6 +3,7 @@ package report
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Armur-Ai/Pentest-Swarm-AI/internal/llm"
@@ -89,9 +90,28 @@ func (r *ReportAgent) generateSection(ctx context.Context, section string, campa
 	var prompt string
 	switch section {
 	case "executive_summary":
+		// Compte reel par severite plutot que d'affirmer a tort au modele
+		// que tous les findings sont "critical, high-severity" (bug d'origine:
+		// le prompt utilisait len(findings) avec un texte fixe mentionnant
+		// "critical, high-severity" quelle que soit la severite reelle).
+		var critical, high, medium, low, info int
+		for _, f := range findings {
+			switch f.Severity {
+			case pipeline.SeverityCritical:
+				critical++
+			case pipeline.SeverityHigh:
+				high++
+			case pipeline.SeverityMedium:
+				medium++
+			case pipeline.SeverityLow:
+				low++
+			default:
+				info++
+			}
+		}
 		prompt = fmt.Sprintf(
-			"Write a 2-3 paragraph executive summary for a penetration test report.\nTarget: %s\nObjective: %s\nTotal findings: %d critical, high-severity findings. Focus on business risk, not technical details. Write for a non-technical audience.",
-			campaign.Target, campaign.Objective, len(findings),
+			"Write a 2-3 paragraph executive summary for a penetration test report.\nTarget: %s\nObjective: %s\nFindings by severity: %d critical, %d high, %d medium, %d low, %d info (total %d).\nBase every claim strictly on these counts and the finding titles provided elsewhere in the report — do not invent vulnerability types, data exposure, or business impact that isn't supported by the findings. If there are 0 critical and 0 high findings, say so plainly rather than describing the results as critical. Focus on business risk, not technical details. Write for a non-technical audience.",
+			campaign.Target, campaign.Objective, critical, high, medium, low, info, len(findings),
 		)
 	default:
 		return "", fmt.Errorf("unknown section: %s", section)
@@ -111,12 +131,20 @@ func (r *ReportAgent) generateSection(ctx context.Context, section string, campa
 }
 
 func (r *ReportAgent) generateRemediation(ctx context.Context, finding pipeline.ClassifiedFinding) (string, error) {
+	description := finding.Description
+	if description == "" {
+		// La description peut arriver vide depuis le classifier (deja
+		// observe en degraded mode). Sans ce garde-fou, le modele demande
+		// des precisions a l'utilisateur en plein milieu du rapport livre
+		// au lieu de produire une remediation generique exploitable.
+		description = "No detailed description was captured for this finding. Base your remediation on the title, severity, and target alone."
+	}
 	resp, err := r.provider.Complete(ctx, llm.CompletionRequest{
-		SystemPrompt: "You are a security remediation expert. Provide specific, actionable remediation steps.",
+		SystemPrompt: "You are a security remediation expert. Provide specific, actionable remediation steps. Never ask the user for more information or offer alternative tailored plans — this text goes directly into a delivered report with no follow-up turn. If the input lacks detail, give the best generic remediation for the finding type and say nothing about the missing detail.",
 		Messages: []llm.Message{
 			{
 				Role:    "user",
-				Content: fmt.Sprintf("Provide remediation steps for this vulnerability:\nTitle: %s\nSeverity: %s\nCVSS: %.1f\nDescription: %s", finding.Title, finding.Severity, finding.CVSSScore, finding.Description),
+				Content: fmt.Sprintf("Provide remediation steps for this vulnerability:\nTitle: %s\nSeverity: %s\nCVSS: %.1f\nDescription: %s", finding.Title, finding.Severity, finding.CVSSScore, description),
 			},
 		},
 		MaxTokens:   1024,
@@ -129,12 +157,39 @@ func (r *ReportAgent) generateRemediation(ctx context.Context, finding pipeline.
 }
 
 func (r *ReportAgent) generateNarrative(ctx context.Context, campaign pipeline.Campaign, plan *pipeline.AttackPlan, results []pipeline.ExecutionResult) (string, error) {
+	// Transmet le detail reel de chaque etape (commande, succes/echec,
+	// extrait de sortie) plutot que de simples compteurs. Sans ca, le
+	// modele n'a aucune donnee sur ce qui s'est vraiment passe et invente
+	// une histoire generique (nmap/dirb/Burp Suite, SQLi/XSS testes...)
+	// sans rapport avec les etapes reellement executees ou bloquees.
+	var resultsBuilder strings.Builder
+	if len(results) == 0 {
+		resultsBuilder.WriteString("No steps executed (all planned steps were blocked before execution).")
+	}
+	for i, res := range results {
+		status := "FAILED"
+		if res.Success {
+			status = "SUCCEEDED"
+		}
+		output := res.Output
+		if len(output) > 500 {
+			output = output[:500] + "... (truncated)"
+		}
+		resultsBuilder.WriteString(fmt.Sprintf(
+			"Step %d [%s]: command=%q output=%q\n",
+			i+1, status, res.CommandExecuted, output,
+		))
+	}
+
 	resp, err := r.provider.Complete(ctx, llm.CompletionRequest{
-		SystemPrompt: "You are a penetration testing report writer. Write the attack narrative as a sequence of events, telling the story of this penetration test from initial recon to final findings.",
+		SystemPrompt: "You are a penetration testing report writer. Write the attack narrative as a sequence of events, telling the story of this penetration test from initial recon to final findings. Base every step strictly on the execution log provided — never invent tools, commands, or outcomes that are not in that log. If a step was blocked or failed, say so plainly rather than describing a fictional successful test.",
 		Messages: []llm.Message{
 			{
-				Role:    "user",
-				Content: fmt.Sprintf("Write an attack narrative for target %s. %d attack paths were tested with %d execution results. Reasoning: %s", campaign.Target, len(plan.Paths), len(results), plan.Reasoning),
+				Role: "user",
+				Content: fmt.Sprintf(
+					"Write an attack narrative for target %s. Planner reasoning: %s\n\nActual execution log (%d steps):\n%s",
+					campaign.Target, plan.Reasoning, len(results), resultsBuilder.String(),
+				),
 			},
 		},
 		MaxTokens:   2048,

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -287,7 +287,9 @@ func (r *Runner) Run(ctx context.Context, cc CampaignConfig, onEvent EventCallba
 
 	var attackPlan *pipeline.AttackPlan
 	if !cc.DryRun && len(findingSet.Findings) > 0 {
-		attackPlan, err = exploitAgent.BuildPlan(ctx, *findingSet, cc.Objective)
+		// On transmet la liste des outils reellement autorises par l'executor
+		// pour que le planificateur ne propose plus curl/wget/shell brut.
+		attackPlan, err = exploitAgent.BuildPlan(ctx, *findingSet, cc.Objective, coordinator.RegisteredToolNames())
 		if err != nil {
 			emit(pipeline.EventError, "exploit", fmt.Sprintf("Plan construction failed: %s", err))
 		} else {
@@ -324,6 +326,9 @@ func (r *Runner) Run(ctx context.Context, cc CampaignConfig, onEvent EventCallba
 				result, err := executor.Execute(ctx, step, campaignID)
 				if err != nil {
 					emit(pipeline.EventError, "exploit", fmt.Sprintf("Step failed: %s", err))
+					if result != nil {
+						execResults = append(execResults, *result)
+					}
 					continue
 				}
 				execResults = append(execResults, *result)

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -40,7 +40,7 @@ func NewOllamaProvider(cfg OllamaProviderConfig) *OllamaProvider {
 		model:         cfg.Model,
 		contextWindow: cfg.ContextWindow,
 		httpClient: &http.Client{
-			Timeout: 10 * time.Minute, // long timeout for LLM inference
+			Timeout: 30 * time.Minute, // long timeout for LLM inference
 		},
 	}
 }
@@ -52,6 +52,7 @@ type ollamaChatRequest struct {
 	Stream   bool                `json:"stream"`
 	Options  ollamaOptions       `json:"options,omitempty"`
 	Tools    []ollamaTool        `json:"tools,omitempty"`
+	Think    bool                `json:"think"`
 }
 
 type ollamaChatMessage struct {
@@ -292,6 +293,7 @@ func (o *OllamaProvider) buildRequest(req CompletionRequest, stream bool) ollama
 			NumPredict:  req.MaxTokens,
 			NumCtx:      o.contextWindow,
 		},
+		Think: false,
 	}
 
 	// Convert tools

--- a/internal/swarm/agents/exploit.go
+++ b/internal/swarm/agents/exploit.go
@@ -72,7 +72,13 @@ func (a *ExploitAgent) Handle(ctx context.Context, f blackboard.Finding, board b
 		CampaignID: a.campaignID,
 		Findings:   []pipeline.ClassifiedFinding{cf},
 	}
-	plan, err := a.exploit.BuildPlan(ctx, set, a.objective)
+	// On expose les outils reellement autorises par l'executor (garde nil ->
+	// slice vide) pour contraindre le planificateur a l'allowlist.
+	var allowedTools []string
+	if a.executor != nil {
+		allowedTools = a.executor.AllowedToolNames()
+	}
+	plan, err := a.exploit.BuildPlan(ctx, set, a.objective, allowedTools)
 	if err != nil {
 		return fmt.Errorf("build plan: %w", err)
 	}


### PR DESCRIPTION
## Summary
- `internal/swarm/agents/exploit.go` had been overwritten wholesale with `runner.go`'s content during a manual edit (wrong package, wrong file), breaking the build. Restored from `main` and re-applied the `BuildPlan` call-site update for its new 4th parameter (allowed tool names).
- `BuildPlan(ctx, findings, objective, allowedTools)` now threads the executor's registered tool names into the LLM prompt so the planner stops proposing `curl`/`wget`/raw shell steps that the executor rejects — and the same constraint now also applies to `cleanup_command`, which was still defaulting to `rm` and getting rejected for the same reason.
- `ollama.go`: disable Qwen3 "think" mode so it stops polluting expected JSON responses.
- `report/agent.go`: fix executive summary always claiming "critical, high-severity" regardless of the actual severity distribution.
- `executor.go`: expose `AllowedToolNames()` so callers can inspect the allowlist before building a plan.
- `Dockerfile`/`docker-compose`: compile and ship the recon toolchain (nuclei, subfinder, httpx, naabu, katana, dnsx, gau) that the upstream image didn't include, and mount `config.yaml` to work around a Viper env-var gap on `orchestrator.endpoint`/`model`.

## Test plan
- [x] `go build ./...` passes
- [x] `docker compose -f deploy/docker-compose.yml up -d --build pentestswarm` builds and starts cleanly
- [x] Full scan against a live OWASP Juice Shop target completes end-to-end (recon → classify → plan → execute → report)
- [x] Executive summary reflects the real severity distribution (no more false "critical, high-severity" claim on 0/0 findings)
- [x] No `curl`/raw shell steps or "not in allowed tool surface" rejections in scan logs — planner only proposes registered tool adapters
- [x] Remediation sections contain no user-directed questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)